### PR TITLE
feat(cloud): support every Miele sales-company region in cloud pairing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 # --- Claude / development context ---
 .claude/
 # tools/ is gitignored — the directory contents are RE scratchpads. The
-# only public-facing helper is the provisioning CLI referenced from README.
+# only public-facing helpers are the provisioning CLI referenced from README
+# and the MAP country-table generator that cloud.py's tables are derived from.
 tools/*
 !tools/miele_lan_provision.py
+!tools/dump_map_countries.py
 .idea/
 *.iml
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ dns-sd -B _mieleathome._tcp local.
 
 If nothing appears, your network is dropping the multicast — fix that before going further. Common culprits: IGMP-snooping on a managed switch with no IGMP querier, a VLAN ACL between HA and the appliance subnet, an mDNS-blocking firewall rule, or HA running in a Docker bridge (use `network_mode: host`).
 
+**Setup fails with "household … has no appliances"?** Check the log for a second line naming a *different* household. Miele's cloud only hands over the key for the household your account currently owns; if your appliances were commissioned into an earlier one — an app reinstall or a re-pair can do this — the two no longer match, and the cloud's household comes back empty. The Miele app keeps working because it holds the LAN key itself. Fix it by re-pairing the appliances in the Miele app so they join the current household, or by using **Paste household credentials** if you can obtain the GroupKey for the group the appliances actually advertise. If instead the log says no Miele appliance answered mDNS *at all*, it is a network problem — see above.
+
 **Push not firing (sensors only update every 30 s)?** Verify `Mobile Controllable` is on at the appliance, and that HA's listener port (default 18082) is reachable from the appliance subnet. Look for `push:active` in the diagnostic Push State sensor.
 
 **`HTTP error 403` on writes?** The appliance's `RemoteEnable` flag for `MobileCtrl` is `0`. Enable Mobile Controllable on the panel. Fridges, freezers, and wine cabinets stay 403 by firmware design — see Limitations.

--- a/README.md
+++ b/README.md
@@ -63,11 +63,30 @@ Copy `custom_components/miele_lan/` into your HA config (final path: `<config>/c
 
 **Settings → Devices & services → Add Integration → Miele@LAN.** Three setup paths:
 
-- **Cloud pairing (recommended).** Log in once with your Miele account; HA fetches the household `GroupKey` from `rest-eu.domestic.miele-iot.com`, mDNS-discovers every appliance, and provisions a SuperVision push listener. The Miele app continues to work in parallel.
+- **Cloud pairing (recommended).** Log in once with your Miele account; HA fetches the household `GroupKey` from Miele's cloud, mDNS-discovers every appliance, and provisions a SuperVision push listener. The Miele app continues to work in parallel. Pick the country your Miele *account* is registered with — that is the sales company, not necessarily where you live now; HA works out which regional backend holds your household on its own.
 - **Paste pre-obtained tokens.** Skip the in-flow OAuth if you already have an `access_token` + `refresh_token` from a Miele OAuth flow against `prod.map.miele-iot.com` (e.g. captured during the Cloud-pairing step in another HA instance).
-- **Paste household credentials.** If you've already extracted `GroupID` + `GroupKey` (e.g. from `MieleRESTServer`), paste them directly — no cloud round-trip needed.
+- **Paste household credentials.** If you've already extracted `GroupID` + `GroupKey` (e.g. from `MieleRESTServer`), paste them directly — no cloud round-trip needed. This path never touches the cloud, so it works regardless of which country your account belongs to.
 
 For factory-fresh appliances, run `python tools/miele_lan_provision.py` on your laptop first to commission them — this writes a new `GroupID`/`GroupKey` and binds the appliance to your LAN.
+
+### Supported countries (cloud pairing)
+
+Cloud pairing works for every sales company Miele's MAP gateway serves — 49 at the time of
+writing, covering Europe, the Americas, and Asia-Pacific:
+
+```
+ae at au be bg br ca ch cl cn cy cz de dk ee es fi fr gb gr hk hr hu ie in it jp kr
+lt lu lv mx my nl no nz pl pt ro rs se sg si sk th tr ua us za
+```
+
+Regenerate the table against the live gateway with:
+
+```sh
+python tools/dump_map_countries.py --check    # exits non-zero if Miele changed anything
+```
+
+If your country is genuinely absent, use **Paste household credentials** instead — that path
+is region-independent.
 
 ### Capturing the OAuth redirect (Cloud pairing)
 

--- a/custom_components/miele_lan/__init__.py
+++ b/custom_components/miele_lan/__init__.py
@@ -94,10 +94,6 @@ async def _setup_cloud(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # now).
     static_ips: dict[str, str] = entry.data.get(CONF_STATIC_IPS) or {}
 
-    if not devices:
-        _LOGGER.warning("cloud entry has no devices — nothing to set up")
-        return False
-
     # HA's LAN-facing IP on the interface that routes toward the appliances.
     # If we know any appliance IP, route toward it (multi-homed boxes pick the
     # right interface). Otherwise just toward a public IP.
@@ -135,11 +131,30 @@ async def _setup_cloud(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                      len(mdns_static), mdns_static)
     merged_static_ips = {**static_ips, **mdns_static}
     if not devices and mdns_results:
+        # The cloud can return a household with an empty device list — observed
+        # on an `au` account whose appliances the Miele app shows fine. mDNS is
+        # authoritative for what is actually on the LAN, so adopt what it found.
+        _LOGGER.info(
+            "cloud listed no devices; adopting the %d appliance(s) mDNS found",
+            len(mdns_results),
+        )
         devices = [
             {"fabNr": r["fabNr"], "deviceType": r.get("deviceType", 0),
              "deviceName": ""}
             for r in mdns_results
         ]
+
+    if not devices:
+        # Only now is this fatal: neither source knows of an appliance. Bailing
+        # before the mDNS browse (as this used to) made the fallback above dead
+        # code, since it is reachable only when the cloud list is empty.
+        _LOGGER.warning(
+            "household %s has no appliances — the cloud listed none and none "
+            "answered mDNS on this LAN. Check HA shares a broadcast domain "
+            "with the appliances (see the mDNS notes in the README).",
+            group_id,
+        )
+        return False
 
     # Step 2: bring up the push listener (uses the same shared zeroconf).
     async def _on_push(event: PushEvent) -> None:

--- a/custom_components/miele_lan/__init__.py
+++ b/custom_components/miele_lan/__init__.py
@@ -44,6 +44,7 @@ from .enrollment import (
     cleanup_stale_subscriptions,
     enroll_all,
     mdns_discover_household,
+    mdns_household_ids,
 )
 from .push_listener import (
     MielePushListener,
@@ -148,12 +149,31 @@ async def _setup_cloud(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Only now is this fatal: neither source knows of an appliance. Bailing
         # before the mDNS browse (as this used to) made the fallback above dead
         # code, since it is reachable only when the cloud list is empty.
-        _LOGGER.warning(
-            "household %s has no appliances — the cloud listed none and none "
-            "answered mDNS on this LAN. Check HA shares a broadcast domain "
-            "with the appliances (see the mDNS notes in the README).",
-            group_id,
-        )
+        #
+        # Distinguish "no Miele appliances here" from "appliances here, but in a
+        # different household". They look identical in the log otherwise, and
+        # the second one sends people hunting for an mDNS fault they don't have.
+        lan_groups = await mdns_household_ids(timeout=4.0, zeroconf=shared_zc)
+        others = sorted(lan_groups - {group_id.upper()})
+        if others:
+            _LOGGER.error(
+                "household %s has no appliances, but this LAN has Miele "
+                "appliance(s) in household %s. Your appliances are commissioned "
+                "into a group your Miele account does not currently own, so the "
+                "cloud cannot hand over its key. Re-pair them in the Miele app "
+                "so they join the account's current household, or set the "
+                "integration up with 'Paste household credentials' if you can "
+                "obtain the GroupKey for %s.",
+                group_id, ", ".join(others), others[0],
+            )
+        else:
+            _LOGGER.warning(
+                "household %s has no appliances — the cloud listed none and no "
+                "Miele appliance answered mDNS on this LAN at all. Check HA "
+                "shares a broadcast domain with the appliances (see the mDNS "
+                "notes in the README).",
+                group_id,
+            )
         return False
 
     # Step 2: bring up the push listener (uses the same shared zeroconf).

--- a/custom_components/miele_lan/cloud.py
+++ b/custom_components/miele_lan/cloud.py
@@ -23,28 +23,117 @@ import aiohttp
 
 _LOGGER = logging.getLogger(__name__)
 
-# Per-country MAP consumer client_ids (extracted from official Android APK).
-# Same Gigya tenant `4_j_ZiR1Ejz2QKP4NFcYnOZw` is shared; only the MAP wrapper
-# differs per country.
+# Per-country MAP consumer client_ids. Regenerate with
+# `python tools/dump_map_countries.py`: Miele's MAP gateway serves these itself
+# over an unauthenticated redirect, so they no longer have to be lifted out of
+# the Android APK. The 18 countries that were originally APK-extracted reproduce
+# byte-for-byte through that probe, which is what pins the two sources together.
+# (The old note here claimed every country shares one Gigya tenant — it does not:
+# each sales company has its own tenant, in one of three Gigya data centres.)
 CONSUMER_CLIENT_IDS: dict[str, str] = {
+    "ae": "iaXIbUAGv6QTUd8FRNPG5fHN",
     "at": "wNv9HJ3ZcFKH4bxvz0LExQuw",
+    "au": "rLXHMAq2VdnICd0eHuefA50w",
+    "be": "JFDW4KGg_ppC3kmSOITHNKBp",
+    "bg": "v6R8ClqnHRWVYJBlhxah0fiR",
+    "br": "zu0ZoLtw2HUj5GH_I_nHfQxM",
+    "ca": "-fZUlMeq5FaRsG5UNgtMpr-e",
     "ch": "V52nWiniHyVotglJKplSXnX8",
+    "cl": "_BRdHKYtaYRpqk7j67y1mc4W",
+    "cn": "_4vxrtrxGJeUNaBd4zTkeSZ2",
+    "cy": "9se3MtP42BbyWUIQBaE9c8NE",
     "cz": "npoAzuJP6okjvJ0NqUq9i5Rv",
     "de": "UJgKOxacIul2BcPJAzrQE6p0",
     "dk": "xWgykqRQSa9THqOXWfzZbxsH",
+    "ee": "m_4y2qk8ntJbOqu6kx7PYXOB",
     "es": "D0Q4NPBR9dwP2EjX4E0_CtHE",
+    "fi": "8JbG7QQsdvEMsYisC_nUfltr",
     "fr": "SOiiE3R4tSD0VxYYBvB8Pi_J",
     "gb": "WigtLzKGJE1Wg6yeZUECV8-P",
+    "gr": "meyCOw7Co2ICAx5ZCMb21oiE",
+    "hk": "tfbB9jidNn1ahn3_oiTrv8um",
     "hr": "HD4OUUQYAw_5DtVFSe4-rYzR",
     "hu": "2mm2yscHPGJ4tJCVjd6mp-to",
+    "ie": "_UU4TA2Iei5eEf0XkYp3ZRKF",
+    "in": "5KwIy81GoVqNkxkB20OtTNaf",
     "it": "ARQyaYB0ZxLxJ1SJcjJgctuV",
+    "jp": "wk4iaS04nYkN4seEsZbKQ2xB",
+    "kr": "_e5CgRBpM9h9ecVoUhpZl9-h",
+    "lt": "KzeuROL469pqvGFjSYp2ivQ2",
+    "lu": "34UAt-gA9ADx2DWgBbtoQh6X",
+    "lv": "MJhu3mAsyk7Tahso0i_7m1ud",
+    "mx": "G_FW4x4rXuwJ6v2VFx2REn34",
+    "my": "esJDemY095qO2Os6VPhAtky0",
     "nl": "7ItTbQXQ1wthDOue9jvBQ7Iz",
+    "no": "411mmVRPOnTNmViGl5aDc5h8",
+    "nz": "RtYo_k74PpIFsLBsrcRk9238",
     "pl": "jWbgLScpvIuqjUoYvf1jS-Is",
     "pt": "5ZVD-CuJvpG4YpCO9pQhtrGQ",
+    "ro": "AQJyFJC8kgsHvKnC2druvJn1",
+    "rs": "qbkOxTdY-dx-0AswysR75wU-",
     "se": "3Mm7m1gD1eU_sUh8yxmShL6S",
+    "sg": "x798Jlx93o8YAL3Lg0dDwdzU",
     "si": "UTyhG21RchpI8FPbNeb1vFg1",
     "sk": "pGeafLwcC1_BCLr8DRTCVxSt",
+    "th": "kY1LYjhV5Wy8L3Jxe9rh_vYr",
+    "tr": "ZSHeNOPc9DcFfqNY42LQAIdl",
+    "ua": "bDsz9awSMOt-631KZK2J7dUg",
     "us": "HpsWh2gzgKqRBduPpkZ4Yui9",
+    "za": "A0sngQGYP8ZvfZ100eJGZD4M",
+}
+
+# Country -> Gigya data centre backing that sales company, from the same probe.
+# Used only to order the REST backends in `region_candidates()`.
+GIGYA_DC_BY_COUNTRY: dict[str, str] = {
+    "ae": "eu1",
+    "at": "eu1",
+    "au": "au1",
+    "be": "eu1",
+    "bg": "eu1",
+    "br": "us1",
+    "ca": "us1",
+    "ch": "eu1",
+    "cl": "us1",
+    "cn": "eu1",
+    "cy": "eu1",
+    "cz": "eu1",
+    "de": "eu1",
+    "dk": "eu1",
+    "ee": "eu1",
+    "es": "eu1",
+    "fi": "eu1",
+    "fr": "eu1",
+    "gb": "eu1",
+    "gr": "eu1",
+    "hk": "us1",
+    "hr": "eu1",
+    "hu": "eu1",
+    "ie": "eu1",
+    "in": "eu1",
+    "it": "eu1",
+    "jp": "us1",
+    "kr": "us1",
+    "lt": "eu1",
+    "lu": "eu1",
+    "lv": "eu1",
+    "mx": "us1",
+    "my": "au1",
+    "nl": "eu1",
+    "no": "eu1",
+    "nz": "au1",
+    "pl": "eu1",
+    "pt": "eu1",
+    "ro": "eu1",
+    "rs": "eu1",
+    "se": "eu1",
+    "sg": "au1",
+    "si": "eu1",
+    "sk": "eu1",
+    "th": "au1",
+    "tr": "eu1",
+    "ua": "eu1",
+    "us": "us1",
+    "za": "eu1",
 }
 
 REDIRECT_URI = "miele://oauth2-code/"
@@ -57,6 +146,24 @@ REST_HOST_BY_REGION: dict[str, str] = {
     "AS": "rest-as.domestic.miele-iot.com",
     "EU2": "rest-eu2.domestic.miele-iot.com",
 }
+
+# Only two backends sit behind those names: `rest-eu` and `rest-eu2` resolve to one
+# address, `rest-as` and `rest-as2` to another (checked 2026-08-22). That is why a
+# wrong first guess is cheap to recover from — see `region_candidates()`.
+
+
+def region_candidates(cc: str) -> list[str]:
+    """REST regions to try, best guess first, for a sales company.
+
+    The Gigya data centre named in the MAP authorize redirect is the only signal
+    available, and it does not map to a REST backend by any documented rule — so
+    this is a preference order, not a lookup. Since `/V2/GroupKeyId/` is a plain
+    GET against one of two hosts, the caller can just try both and keep whichever
+    serves the household. That beats maintaining a country -> region table nobody
+    can verify for every market, which is what previously limited setup to the EU.
+    """
+    dc = GIGYA_DC_BY_COUNTRY.get(cc.lower(), "eu1")
+    return ["AS", "EU"] if dc == "au1" else ["EU", "AS"]
 
 
 def _b64url(b: bytes) -> str:
@@ -82,6 +189,7 @@ class GroupKey:
     group_id: str
     group_key: str
     devices: list[dict[str, Any]]
+    region: str = ""  # REST backend that answered — persist to skip the search later
 
 
 def build_authorize_url(cc: str) -> tuple[str, PKCEChallenge]:
@@ -206,22 +314,17 @@ async def refresh_access_token(
     return tokens
 
 
-async def fetch_groupkey(
-    session: aiohttp.ClientSession,
-    access_token: str,
-    region: str = "EU",
-) -> GroupKey:
-    """GET /V2/GroupKeyId/ → household key + device list.
+async def _groupkey_from_host(
+    session: aiohttp.ClientSession, access_token: str, host: str
+) -> GroupKey | None:
+    """One backend's answer to /V2/GroupKeyId/, or None when it holds no household.
 
-    `region` derives from the sales company. EU covers DE/AT/CH/etc.
+    Raises on 403: that means the token is missing the `mcs` scope, which is a
+    token problem rather than a wrong-backend one, so the other host cannot help.
     """
-    host = REST_HOST_BY_REGION.get(region.upper())
-    if not host:
-        raise ValueError(f"unknown region {region!r}")
     headers = {
         "Authorization": f"Bearer {access_token}",
         "Accept": "application/json",
-        "Accept-Language": "de-DE",
         "User-Agent": "Miele@LAN/0.3 (Home Assistant)",
     }
     async with session.get(
@@ -234,10 +337,13 @@ async def fetch_groupkey(
             raise RuntimeError(
                 f"GroupKeyId returned 403 — token likely missing `mcs` scope. body={body}"
             )
-        r.raise_for_status()
+        if r.status != 200:
+            _LOGGER.debug("%s answered HTTP %s for /V2/GroupKeyId/", host, r.status)
+            return None
         groups = await r.json(content_type=None)
     if not groups:
-        raise RuntimeError("no household returned — account has no paired devices?")
+        _LOGGER.debug("%s knows no household for this token", host)
+        return None
     g = groups[0]  # exactly one household per account in normal use
     return GroupKey(
         group_id=g["groupId"],
@@ -246,10 +352,40 @@ async def fetch_groupkey(
     )
 
 
+async def fetch_groupkey(
+    session: aiohttp.ClientSession,
+    access_token: str,
+    region: str | None = None,
+    cc: str | None = None,
+) -> GroupKey:
+    """GET /V2/GroupKeyId/ → household key + device list.
+
+    Pass `region` when it is already known — a configured entry records the one
+    that worked. Leave it None and the backends from `region_candidates(cc)` are
+    tried in order until one returns a household; the winner comes back on
+    `GroupKey.region`, so setup works for a sales company whose backend we have
+    never seen without anyone having to hand-maintain a country → region table.
+    """
+    regions = [region.upper()] if region else region_candidates(cc or "de")
+    for candidate in regions:
+        host = REST_HOST_BY_REGION.get(candidate)
+        if not host:
+            raise ValueError(f"unknown region {candidate!r}")
+        groupkey = await _groupkey_from_host(session, access_token, host)
+        if groupkey:
+            groupkey.region = candidate
+            return groupkey
+    raise RuntimeError(
+        f"no household returned by {', '.join(regions)} — the account has no "
+        f"paired devices, or its keys live on a backend we did not try"
+    )
+
+
 async def fetch_pairing_tan(
     session: aiohttp.ClientSession,
     access_token: str,
-    region: str = "EU",
+    region: str | None = None,
+    cc: str | None = None,
 ) -> str:
     """GET /V2/TAN/ → cloud-issued one-shot TAN for the next commissioning.
 
@@ -261,13 +397,15 @@ async def fetch_pairing_tan(
 
     Returns the bare TAN string from the `Tan` field. Raises on non-200.
     """
-    host = REST_HOST_BY_REGION.get(region.upper())
+    # Unlike GroupKeyId this issues a one-shot TAN, so it must not be probed
+    # across backends — take the caller's region, or the best guess for `cc`.
+    region = (region or region_candidates(cc or "de")[0]).upper()
+    host = REST_HOST_BY_REGION.get(region)
     if not host:
         raise ValueError(f"unknown region {region!r}")
     headers = {
         "Authorization": f"Bearer {access_token}",
         "Accept": "application/json",
-        "Accept-Language": "de-DE",
         "User-Agent": "Miele@LAN/0.3 (Home Assistant)",
     }
     async with session.get(
@@ -293,6 +431,8 @@ __all__ = [
     "REDIRECT_URI",
     "OAUTH_SCOPE",
     "REST_HOST_BY_REGION",
+    "GIGYA_DC_BY_COUNTRY",
+    "region_candidates",
     "PKCEChallenge",
     "GroupKey",
     "build_authorize_url",

--- a/custom_components/miele_lan/cloud.py
+++ b/custom_components/miele_lan/cloud.py
@@ -325,6 +325,13 @@ async def _groupkey_from_host(
     headers = {
         "Authorization": f"Bearer {access_token}",
         "Accept": "application/json",
+        # Keep sending this even though the payload carries no localised text.
+        # Dropping it made both backends answer HTTP 500 for an `au` account
+        # (2026-08-22), so something server-side wants a locale present. The
+        # value itself appears not to matter, only that there is one — leave it
+        # at the value the EU-only builds shipped rather than inventing a
+        # per-country locale we cannot test.
+        "Accept-Language": "de-DE",
         "User-Agent": "Miele@LAN/0.3 (Home Assistant)",
     }
     async with session.get(
@@ -338,7 +345,10 @@ async def _groupkey_from_host(
                 f"GroupKeyId returned 403 — token likely missing `mcs` scope. body={body}"
             )
         if r.status != 200:
-            _LOGGER.debug("%s answered HTTP %s for /V2/GroupKeyId/", host, r.status)
+            _LOGGER.debug(
+                "%s answered HTTP %s for /V2/GroupKeyId/: %s",
+                host, r.status, (await r.text())[:300],
+            )
             return None
         groups = await r.json(content_type=None)
     if not groups:
@@ -406,6 +416,7 @@ async def fetch_pairing_tan(
     headers = {
         "Authorization": f"Bearer {access_token}",
         "Accept": "application/json",
+        "Accept-Language": "de-DE",  # see _groupkey_from_host
         "User-Agent": "Miele@LAN/0.3 (Home Assistant)",
     }
     async with session.get(

--- a/custom_components/miele_lan/cloud.py
+++ b/custom_components/miele_lan/cloud.py
@@ -156,8 +156,10 @@ def region_candidates(cc: str) -> list[str]:
     """REST regions to try, best guess first, for a sales company.
 
     The Gigya data centre named in the MAP authorize redirect is the only signal
-    available, and it does not map to a REST backend by any documented rule — so
-    this is a preference order, not a lookup. Since `/V2/GroupKeyId/` is a plain
+    available, and it demonstrably does NOT map to a REST backend: an `au`
+    account sits in Gigya's au1 data centre while its household lives on
+    rest-eu (captured from the Miele iOS app, 2026-08-22). Treat this purely as
+    which backend to ask first; `fetch_groupkey` must try the others regardless. Since `/V2/GroupKeyId/` is a plain
     GET against one of two hosts, the caller can just try both and keep whichever
     serves the household. That beats maintaining a country -> region table nobody
     can verify for every market, which is what previously limited setup to the EU.
@@ -420,6 +422,9 @@ async def fetch_groupkey(
     never seen without anyone having to hand-maintain a country → region table.
     """
     regions = [region.upper()] if region else region_candidates(cc or "de")
+    wanted = {g.upper() for g in (prefer_group_ids or set())}
+    fallback: GroupKey | None = None
+
     for candidate in regions:
         host = REST_HOST_BY_REGION.get(candidate)
         if not host:
@@ -427,9 +432,36 @@ async def fetch_groupkey(
         groupkey = await _groupkey_from_host(
             session, access_token, host, prefer_group_ids
         )
-        if groupkey:
-            groupkey.region = candidate
+        if not groupkey:
+            continue
+        groupkey.region = candidate
+
+        # Nothing to match against: first backend that answers wins, as before.
+        if not wanted:
             return groupkey
+
+        if groupkey.group_id.upper() in wanted:
+            return groupkey
+
+        # A backend answered, but with a household this LAN knows nothing about.
+        # Keep looking — the other backend may hold the one we actually want.
+        # An `au` account is served by rest-eu despite sitting in Gigya's au1
+        # data centre, and stopping at the first answer picked up an unrelated
+        # empty household from rest-as while the live one sat on rest-eu.
+        _LOGGER.debug(
+            "%s offered household %s, which is not on this LAN — trying the rest",
+            host, groupkey.group_id,
+        )
+        if fallback is None:
+            fallback = groupkey
+
+    if fallback is not None:
+        _LOGGER.warning(
+            "no backend offered a household matching this LAN (%s); falling back "
+            "to %s from %s", sorted(wanted), fallback.group_id, fallback.region,
+        )
+        return fallback
+
     raise RuntimeError(
         f"no household returned by {', '.join(regions)} — the account has no "
         f"paired devices, or its keys live on a backend we did not try"

--- a/custom_components/miele_lan/cloud.py
+++ b/custom_components/miele_lan/cloud.py
@@ -314,8 +314,39 @@ async def refresh_access_token(
     return tokens
 
 
+def _pick_household(
+    groups: list[dict[str, Any]], prefer_group_ids: set[str] | None
+) -> dict[str, Any]:
+    """Choose which household to set up when the cloud returns several.
+
+    The old code took `groups[0]` and called one household per account "normal".
+    It is not: an account that has been re-paired, or had appliances replaced,
+    keeps the retired households, and the stale one can sort first — observed on
+    an `au` account whose first entry had no devices while the live household
+    held three (2026-08-22).
+
+    Preference order:
+      1. a household the LAN is actually advertising — mDNS is the only
+         authoritative answer to "which of these is in front of me"
+      2. one that lists devices, since an empty list cannot be set up
+      3. the first, preserving the previous behaviour
+    """
+    if prefer_group_ids:
+        for g in groups:
+            if (g.get("groupId") or "").upper() in prefer_group_ids:
+                return g
+        _LOGGER.debug(
+            "no cloud household matches the LAN groups %s — falling back",
+            sorted(prefer_group_ids),
+        )
+    return next((g for g in groups if g.get("devices")), groups[0])
+
+
 async def _groupkey_from_host(
-    session: aiohttp.ClientSession, access_token: str, host: str
+    session: aiohttp.ClientSession,
+    access_token: str,
+    host: str,
+    prefer_group_ids: set[str] | None = None,
 ) -> GroupKey | None:
     """One backend's answer to /V2/GroupKeyId/, or None when it holds no household.
 
@@ -354,11 +385,15 @@ async def _groupkey_from_host(
     if not groups:
         _LOGGER.debug("%s knows no household for this token", host)
         return None
-    g = groups[0]  # exactly one household per account in normal use
     _LOGGER.debug(
-        "%s served a household with %d device(s); payload fields: %s",
-        host, len(g.get("devices") or []), sorted(g),
+        "%s served %d household(s): %s",
+        host, len(groups),
+        [
+            (g.get("groupId"), len(g.get("devices") or []))
+            for g in groups
+        ],
     )
+    g = _pick_household(groups, prefer_group_ids)
     return GroupKey(
         group_id=g["groupId"],
         group_key=g["groupKey"],
@@ -371,8 +406,12 @@ async def fetch_groupkey(
     access_token: str,
     region: str | None = None,
     cc: str | None = None,
+    prefer_group_ids: set[str] | None = None,
 ) -> GroupKey:
     """GET /V2/GroupKeyId/ → household key + device list.
+
+    `prefer_group_ids` are the households mDNS can see on this LAN; when the
+    account owns more than one, that is what decides which is the live one.
 
     Pass `region` when it is already known — a configured entry records the one
     that worked. Leave it None and the backends from `region_candidates(cc)` are
@@ -385,7 +424,9 @@ async def fetch_groupkey(
         host = REST_HOST_BY_REGION.get(candidate)
         if not host:
             raise ValueError(f"unknown region {candidate!r}")
-        groupkey = await _groupkey_from_host(session, access_token, host)
+        groupkey = await _groupkey_from_host(
+            session, access_token, host, prefer_group_ids
+        )
         if groupkey:
             groupkey.region = candidate
             return groupkey
@@ -448,6 +489,7 @@ __all__ = [
     "REST_HOST_BY_REGION",
     "GIGYA_DC_BY_COUNTRY",
     "region_candidates",
+    "_pick_household",
     "PKCEChallenge",
     "GroupKey",
     "build_authorize_url",

--- a/custom_components/miele_lan/cloud.py
+++ b/custom_components/miele_lan/cloud.py
@@ -355,6 +355,10 @@ async def _groupkey_from_host(
         _LOGGER.debug("%s knows no household for this token", host)
         return None
     g = groups[0]  # exactly one household per account in normal use
+    _LOGGER.debug(
+        "%s served a household with %d device(s); payload fields: %s",
+        host, len(g.get("devices") or []), sorted(g),
+    )
     return GroupKey(
         group_id=g["groupId"],
         group_key=g["groupKey"],

--- a/custom_components/miele_lan/config_flow.py
+++ b/custom_components/miele_lan/config_flow.py
@@ -33,7 +33,7 @@ from .cloud import (
     fetch_groupkey,
     parse_redirect_url,
 )
-from .enrollment import mdns_discover_household
+from .enrollment import mdns_discover_household, mdns_household_ids
 from .const import (
     CONF_COUNTRY,
     CONF_DEVICES,
@@ -139,6 +139,18 @@ class MieleLanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
+
+    async def _lan_group_ids(self) -> set[str]:
+        """Households mDNS can see here, used to disambiguate a multi-household
+        account. Best-effort: a failure just means we fall back to guessing."""
+        try:
+            from homeassistant.components import zeroconf as ha_zc
+            shared_zc = await ha_zc.async_get_async_instance(self.hass)
+            return await mdns_household_ids(timeout=4.0, zeroconf=shared_zc)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("LAN household browse failed (ignored): %s", err)
+            return set()
+
     async def _finalise_cloud(self, code: str) -> FlowResult:
         """Exchange the code, fetch the household, create the config entry."""
         assert self._challenge is not None
@@ -155,7 +167,12 @@ class MieleLanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 # No region argument: let fetch_groupkey find the backend that
                 # actually holds this household, and record what it settled on.
-                groupkey = await fetch_groupkey(session, access, cc=self._challenge.cc)
+                # The LAN groups pick the right household if the account owns
+                # more than one.
+                groupkey = await fetch_groupkey(
+                    session, access, cc=self._challenge.cc,
+                    prefer_group_ids=await self._lan_group_ids(),
+                )
             except Exception as err:  # noqa: BLE001
                 _LOGGER.warning("GroupKey fetch failed: %s", err)
                 return self.async_abort(reason="groupkey_failed")
@@ -194,7 +211,10 @@ class MieleLanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 async with aiohttp.ClientSession() as session:
                     try:
-                        groupkey = await fetch_groupkey(session, access, cc=cc)
+                        groupkey = await fetch_groupkey(
+                            session, access, cc=cc,
+                            prefer_group_ids=await self._lan_group_ids(),
+                        )
                     except Exception as err:  # noqa: BLE001
                         _LOGGER.warning("GroupKey fetch failed: %s", err)
                         return self.async_abort(reason="groupkey_failed")

--- a/custom_components/miele_lan/config_flow.py
+++ b/custom_components/miele_lan/config_flow.py
@@ -152,12 +152,10 @@ class MieleLanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             refresh = tokens.get("refresh_token")
             if not access or not refresh:
                 return self.async_abort(reason="oauth_failed")
-            # Region from country code (very simple mapping — extend later).
-            region = "EU"
-            if self._challenge.cc in ("us",):
-                region = "EU2"  # placeholder; real US region TBD
             try:
-                groupkey = await fetch_groupkey(session, access, region=region)
+                # No region argument: let fetch_groupkey find the backend that
+                # actually holds this household, and record what it settled on.
+                groupkey = await fetch_groupkey(session, access, cc=self._challenge.cc)
             except Exception as err:  # noqa: BLE001
                 _LOGGER.warning("GroupKey fetch failed: %s", err)
                 return self.async_abort(reason="groupkey_failed")
@@ -169,7 +167,7 @@ class MieleLanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data={
                 "flow_kind": "cloud",
                 CONF_COUNTRY: self._challenge.cc,
-                CONF_REGION: region,
+                CONF_REGION: groupkey.region,
                 CONF_REFRESH_TOKEN: refresh,
                 CONF_GROUP_ID: groupkey.group_id,
                 CONF_GROUP_KEY: groupkey.group_key,
@@ -194,12 +192,9 @@ class MieleLanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if not access or not refresh:
                 errors["base"] = "invalid_token"
             else:
-                region = "EU"
-                if cc == "us":
-                    region = "EU2"
                 async with aiohttp.ClientSession() as session:
                     try:
-                        groupkey = await fetch_groupkey(session, access, region=region)
+                        groupkey = await fetch_groupkey(session, access, cc=cc)
                     except Exception as err:  # noqa: BLE001
                         _LOGGER.warning("GroupKey fetch failed: %s", err)
                         return self.async_abort(reason="groupkey_failed")
@@ -210,7 +205,7 @@ class MieleLanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     data={
                         "flow_kind": "cloud",
                         CONF_COUNTRY: cc,
-                        CONF_REGION: region,
+                        CONF_REGION: groupkey.region,
                         CONF_REFRESH_TOKEN: refresh,
                         CONF_GROUP_ID: groupkey.group_id,
                         CONF_GROUP_KEY: groupkey.group_key,

--- a/custom_components/miele_lan/enrollment.py
+++ b/custom_components/miele_lan/enrollment.py
@@ -430,6 +430,64 @@ class DeviceIpResolver:
         return found_ip
 
 
+async def mdns_household_ids(
+    *,
+    timeout: float = 4.0,
+    zeroconf: Any | None = None,
+) -> set[str]:
+    """Group IDs advertised by `_mieleathome._tcp.local.` services on this LAN.
+
+    The `group=` TXT record needs no credentials to read, unlike
+    `mdns_discover_household()` which signs a GET /Devices and therefore needs
+    the GroupKey already. That makes this usable *before* setup has a key, to
+    tell which household the appliances in front of us actually belong to —
+    the cloud can list several, and only the LAN knows which one is live.
+    """
+    try:
+        from zeroconf import IPVersion, ServiceStateChange
+        from zeroconf.asyncio import AsyncServiceBrowser, AsyncZeroconf
+    except ImportError:
+        _LOGGER.warning("zeroconf not installed — cannot discover Miele appliances")
+        return set()
+
+    groups: set[str] = set()
+    owns_zc = zeroconf is None
+    zc = zeroconf if zeroconf is not None else AsyncZeroconf(ip_version=IPVersion.V4Only)
+    pending: list[asyncio.Task] = []
+
+    async def _resolve(service_type: str, name: str) -> None:
+        info = await zc.async_get_service_info(service_type, name, timeout=2000)
+        if info is None:
+            return
+        props = {
+            (k.decode("ascii", errors="ignore") if isinstance(k, bytes) else k):
+            (v.decode("utf-8", errors="ignore") if isinstance(v, bytes) else v)
+            for k, v in (info.properties or {}).items()
+        }
+        group = (props.get("group") or "").upper()
+        if group:
+            groups.add(group)
+
+    def _on_state(zeroconf, service_type, name, state_change):  # type: ignore[no-untyped-def]
+        if state_change is ServiceStateChange.Added:
+            pending.append(asyncio.create_task(_resolve(service_type, name)))
+
+    browser = AsyncServiceBrowser(
+        zc.zeroconf, ["_mieleathome._tcp.local."], handlers=[_on_state]
+    )
+    try:
+        await asyncio.sleep(timeout)
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+    finally:
+        await browser.async_cancel()
+        if owns_zc:
+            await zc.async_close()
+
+    _LOGGER.debug("mDNS sees Miele household(s) on this LAN: %s", sorted(groups) or "none")
+    return groups
+
+
 async def mdns_discover_household(
     group_id_hex: str,
     group_key_hex: str,

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,4 @@
 {
   "name": "Miele@LAN",
-  "render_readme": true,
-  "country": ["DE", "AT", "CH"]
+  "render_readme": true
 }

--- a/tests/test_cloud_regions.py
+++ b/tests/test_cloud_regions.py
@@ -234,3 +234,51 @@ async def test_fetch_groupkey_honours_the_lan_group() -> None:
     assert key.group_id == "1111222233334444"
     assert key.group_key == "BBBB"
     assert key.region == "AS"
+
+
+# ------------------------------------------- the household may be on the other
+# backend entirely. Captured from the Miele iOS app on 2026-08-22: an `au`
+# account authenticates against Gigya's au1 data centre but its household lives
+# on rest-eu, while rest-as answers for the same account with an unrelated,
+# empty household. Stopping at the first backend that answers picks the wrong
+# one — which is exactly what happened on the machine this was found on.
+@pytest.mark.asyncio
+async def test_keeps_searching_when_the_first_backend_has_the_wrong_household() -> None:
+    session = _FakeSession({AS_HOST: (200, [STALE]), EU_HOST: (200, [LIVE])})
+    key = await cloud.fetch_groupkey(
+        session, "token", cc="au", prefer_group_ids={"1111222233334444"}
+    )
+    assert key.group_id == "1111222233334444"
+    assert key.region == "EU"
+    assert session.tried == [AS_HOST, EU_HOST]
+
+
+@pytest.mark.asyncio
+async def test_stops_at_the_first_backend_that_matches() -> None:
+    """A match ends the search — no needless call to the other backend."""
+    session = _FakeSession({AS_HOST: (200, [LIVE]), EU_HOST: (200, [LIVE])})
+    key = await cloud.fetch_groupkey(
+        session, "token", cc="au", prefer_group_ids={"1111222233334444"}
+    )
+    assert key.region == "AS"
+    assert session.tried == [AS_HOST]
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_first_answer_when_nothing_matches() -> None:
+    """HA on an isolated VLAN sees no groups; take what we can get."""
+    session = _FakeSession({AS_HOST: (200, [STALE]), EU_HOST: (200, [STALE])})
+    key = await cloud.fetch_groupkey(
+        session, "token", cc="au", prefer_group_ids={"0000000000000000"}
+    )
+    assert key.group_id == "AAAABBBBCCCCDDDD"
+    assert key.region == "AS"
+    assert session.tried == [AS_HOST, EU_HOST]
+
+
+@pytest.mark.asyncio
+async def test_no_lan_hint_keeps_the_old_first_answer_wins_behaviour() -> None:
+    session = _FakeSession({AS_HOST: (200, [STALE]), EU_HOST: (200, [LIVE])})
+    key = await cloud.fetch_groupkey(session, "token", cc="au")
+    assert key.group_id == "AAAABBBBCCCCDDDD"
+    assert session.tried == [AS_HOST]

--- a/tests/test_cloud_regions.py
+++ b/tests/test_cloud_regions.py
@@ -187,3 +187,50 @@ async def test_no_backend_has_the_household() -> None:
     with pytest.raises(RuntimeError, match="no household"):
         await cloud.fetch_groupkey(session, "token", cc="au")
     assert session.tried == [AS_HOST, EU_HOST]
+
+
+# --------------------------------------------------- multi-household accounts
+STALE = {"groupId": "AAAABBBBCCCCDDDD", "groupKey": "AAAA", "devices": []}
+LIVE = {"groupId": "1111222233334444", "groupKey": "BBBB", "devices": [{"fabNr": "1"}]}
+
+
+def test_lan_group_wins_over_order() -> None:
+    """mDNS is authoritative: the household in front of us is the right one."""
+    picked = cloud._pick_household([STALE, LIVE], {"1111222233334444"})
+    assert picked["groupId"] == "1111222233334444"
+
+
+def test_lan_group_wins_even_when_it_lists_no_devices() -> None:
+    empty_but_live = {"groupId": "1111222233334444", "groupKey": "B", "devices": []}
+    with_devices = {"groupId": "AAAABBBBCCCCDDDD", "groupKey": "A",
+                    "devices": [{"fabNr": "9"}]}
+    picked = cloud._pick_household(
+        [with_devices, empty_but_live], {"1111222233334444"}
+    )
+    assert picked["groupId"] == "1111222233334444"
+
+
+def test_falls_back_to_the_household_with_devices() -> None:
+    """No mDNS answer (HA on another VLAN): an empty household can't be set up."""
+    picked = cloud._pick_household([STALE, LIVE], set())
+    assert picked["groupId"] == "1111222233334444"
+
+
+def test_lan_groups_that_match_nothing_are_ignored() -> None:
+    picked = cloud._pick_household([STALE, LIVE], {"0000000000000000"})
+    assert picked["groupId"] == "1111222233334444"
+
+
+def test_single_household_is_returned_unchanged() -> None:
+    assert cloud._pick_household([STALE], set())["groupId"] == "AAAABBBBCCCCDDDD"
+
+
+@pytest.mark.asyncio
+async def test_fetch_groupkey_honours_the_lan_group() -> None:
+    session = _FakeSession({AS_HOST: (200, [STALE, LIVE])})
+    key = await cloud.fetch_groupkey(
+        session, "token", cc="au", prefer_group_ids={"1111222233334444"}
+    )
+    assert key.group_id == "1111222233334444"
+    assert key.group_key == "BBBB"
+    assert key.region == "AS"

--- a/tests/test_cloud_regions.py
+++ b/tests/test_cloud_regions.py
@@ -1,0 +1,189 @@
+"""Tests for the per-country MAP tables and REST backend selection.
+
+`cloud.py` is loaded straight off disk rather than as `custom_components.miele_lan.cloud`,
+because importing the package pulls in `homeassistant`; this module only needs
+aiohttp and the stdlib.
+
+All offline — the live probe lives in `tools/dump_map_countries.py --check`.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "miele_lan_cloud", ROOT / "custom_components" / "miele_lan" / "cloud.py"
+)
+cloud = importlib.util.module_from_spec(_spec)
+sys.modules["miele_lan_cloud"] = cloud  # dataclasses need it registered
+_spec.loader.exec_module(cloud)
+
+
+# The countries that were originally extracted from the Android APK. They are
+# pinned here because `tools/dump_map_countries.py` reproduces every one of them
+# from MAP — if a regeneration ever changes one, that is a real upstream change
+# and not a formatting accident.
+APK_EXTRACTED = {
+    "at": "wNv9HJ3ZcFKH4bxvz0LExQuw",
+    "ch": "V52nWiniHyVotglJKplSXnX8",
+    "cz": "npoAzuJP6okjvJ0NqUq9i5Rv",
+    "de": "UJgKOxacIul2BcPJAzrQE6p0",
+    "dk": "xWgykqRQSa9THqOXWfzZbxsH",
+    "es": "D0Q4NPBR9dwP2EjX4E0_CtHE",
+    "fr": "SOiiE3R4tSD0VxYYBvB8Pi_J",
+    "gb": "WigtLzKGJE1Wg6yeZUECV8-P",
+    "hr": "HD4OUUQYAw_5DtVFSe4-rYzR",
+    "hu": "2mm2yscHPGJ4tJCVjd6mp-to",
+    "it": "ARQyaYB0ZxLxJ1SJcjJgctuV",
+    "nl": "7ItTbQXQ1wthDOue9jvBQ7Iz",
+    "pl": "jWbgLScpvIuqjUoYvf1jS-Is",
+    "pt": "5ZVD-CuJvpG4YpCO9pQhtrGQ",
+    "se": "3Mm7m1gD1eU_sUh8yxmShL6S",
+    "si": "UTyhG21RchpI8FPbNeb1vFg1",
+    "sk": "pGeafLwcC1_BCLr8DRTCVxSt",
+    "us": "HpsWh2gzgKqRBduPpkZ4Yui9",
+}
+
+
+# ------------------------------------------------------------------ the tables
+def test_apk_extracted_ids_unchanged() -> None:
+    for cc, client_id in APK_EXTRACTED.items():
+        assert cloud.CONSUMER_CLIENT_IDS[cc] == client_id, cc
+
+
+def test_tables_cover_the_same_countries() -> None:
+    assert set(cloud.CONSUMER_CLIENT_IDS) == set(cloud.GIGYA_DC_BY_COUNTRY)
+
+
+def test_country_codes_are_lowercase_iso_alpha2() -> None:
+    for cc in cloud.CONSUMER_CLIENT_IDS:
+        assert len(cc) == 2 and cc.islower(), cc
+
+
+def test_every_gigya_dc_is_one_we_know() -> None:
+    assert set(cloud.GIGYA_DC_BY_COUNTRY.values()) <= {"eu1", "us1", "au1"}
+
+
+def test_regions_that_were_previously_unreachable_are_present() -> None:
+    # The countries users reported as missing: issue #6 (sg, be, lv, au).
+    for cc in ("sg", "be", "lv", "au"):
+        assert cc in cloud.CONSUMER_CLIENT_IDS, cc
+
+
+# ------------------------------------------------------------ region ordering
+@pytest.mark.parametrize("cc,expected_first", [
+    ("au", "AS"), ("nz", "AS"), ("sg", "AS"), ("my", "AS"), ("th", "AS"),
+    ("de", "EU"), ("gb", "EU"), ("us", "EU"), ("za", "EU"),
+])
+def test_region_candidates_order(cc: str, expected_first: str) -> None:
+    assert cloud.region_candidates(cc)[0] == expected_first
+
+
+def test_region_candidates_always_covers_both_backends() -> None:
+    for cc in cloud.CONSUMER_CLIENT_IDS:
+        assert set(cloud.region_candidates(cc)) == {"EU", "AS"}, cc
+
+
+def test_region_candidates_tolerates_unknown_country() -> None:
+    assert cloud.region_candidates("zz") == ["EU", "AS"]
+
+
+def test_every_candidate_region_resolves_to_a_host() -> None:
+    for cc in cloud.CONSUMER_CLIENT_IDS:
+        for region in cloud.region_candidates(cc):
+            assert region in cloud.REST_HOST_BY_REGION
+
+
+# ------------------------------------------------------- backend fall-through
+HOUSEHOLD = [{"groupId": "ABC123", "groupKey": "DEADBEEF", "devices": [{"fabNr": "1"}]}]
+
+
+class _FakeResponse:
+    def __init__(self, status: int, payload) -> None:
+        self.status = status
+        self._payload = payload
+
+    async def json(self, content_type=None):
+        return self._payload
+
+    async def text(self) -> str:
+        return str(self._payload)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+
+class _FakeSession:
+    """Answers /V2/GroupKeyId/ per host, and records the order hosts were tried."""
+
+    def __init__(self, by_host: dict) -> None:
+        self._by_host = by_host
+        self.tried: list[str] = []
+
+    def get(self, url: str, **_kw) -> _FakeResponse:
+        host = url.split("/")[2]
+        self.tried.append(host)
+        status, payload = self._by_host.get(host, (401, []))
+        return _FakeResponse(status, payload)
+
+
+EU_HOST = "rest-eu.domestic.miele-iot.com"
+AS_HOST = "rest-as.domestic.miele-iot.com"
+
+
+@pytest.mark.asyncio
+async def test_au_household_found_on_first_try() -> None:
+    session = _FakeSession({AS_HOST: (200, HOUSEHOLD)})
+    key = await cloud.fetch_groupkey(session, "token", cc="au")
+    assert key.group_id == "ABC123"
+    assert key.region == "AS"
+    assert session.tried == [AS_HOST]  # no needless call to the other backend
+
+
+@pytest.mark.asyncio
+async def test_falls_through_to_the_other_backend() -> None:
+    session = _FakeSession({AS_HOST: (401, []), EU_HOST: (200, HOUSEHOLD)})
+    key = await cloud.fetch_groupkey(session, "token", cc="au")
+    assert key.region == "EU"
+    assert session.tried == [AS_HOST, EU_HOST]
+
+
+@pytest.mark.asyncio
+async def test_empty_household_list_is_not_a_match() -> None:
+    """A backend that answers 200 with no household isn't the right one."""
+    session = _FakeSession({EU_HOST: (200, []), AS_HOST: (200, HOUSEHOLD)})
+    key = await cloud.fetch_groupkey(session, "token", cc="de")
+    assert key.region == "AS"
+    assert session.tried == [EU_HOST, AS_HOST]
+
+
+@pytest.mark.asyncio
+async def test_explicit_region_is_not_second_guessed() -> None:
+    session = _FakeSession({EU_HOST: (200, HOUSEHOLD), AS_HOST: (200, HOUSEHOLD)})
+    key = await cloud.fetch_groupkey(session, "token", region="EU", cc="au")
+    assert key.region == "EU"
+    assert session.tried == [EU_HOST]
+
+
+@pytest.mark.asyncio
+async def test_403_aborts_instead_of_trying_the_other_backend() -> None:
+    """403 means the token lacks the `mcs` scope — the other host can't fix that."""
+    session = _FakeSession({AS_HOST: (403, "forbidden"), EU_HOST: (200, HOUSEHOLD)})
+    with pytest.raises(RuntimeError, match="mcs"):
+        await cloud.fetch_groupkey(session, "token", cc="au")
+    assert session.tried == [AS_HOST]
+
+
+@pytest.mark.asyncio
+async def test_no_backend_has_the_household() -> None:
+    session = _FakeSession({})
+    with pytest.raises(RuntimeError, match="no household"):
+        await cloud.fetch_groupkey(session, "token", cc="au")
+    assert session.tried == [AS_HOST, EU_HOST]

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -1,8 +1,10 @@
 """Tests for the provisioning CLI's key generation + payload shapes.
 
-The CLI lives under `tools/` which is gitignored (RE tooling, not shipped via
-HACS). When running CI on a fresh checkout the module isn't available, so the
-whole module is skipped instead of failing collection.
+`tools/*` is gitignored — the directory holds RE scratch work — but the CLI is
+allowlisted back in, so it is present in a fresh checkout. What is not
+guaranteed is its third-party imports: it needs aiohttp and pyyaml, which the
+integration itself does not, so a checkout without them skips this module
+rather than failing collection.
 """
 
 import re
@@ -17,7 +19,7 @@ sys.path.insert(0, str(ROOT / "tools"))
 
 prov = pytest.importorskip(
     "miele_lan_provision",
-    reason="tools/miele_lan_provision.py is gitignored; skip when not present locally",
+    reason="miele_lan_provision needs aiohttp + pyyaml; skip where they are absent",
 )
 
 

--- a/tools/dump_map_countries.py
+++ b/tools/dump_map_countries.py
@@ -1,0 +1,162 @@
+"""Miele@LAN — regenerate the MAP consumer client_id table.
+
+The per-country consumer `client_id` values in `custom_components/miele_lan/cloud.py`
+were originally lifted out of the official Android APK. They do not have to be:
+Miele's MAP gateway hands them out itself, unauthenticated.
+
+  GET https://prod.map.miele-iot.com/{cc}/authorize?client_id=<anything>&...
+
+returns `302` whose `Location` points at the Gigya OIDC endpoint for that sales
+company, and that URL carries the *real* `client_id` — MAP rewrites whatever we
+sent. An unrecognised country returns `200` with no `Location`, so the same probe
+doubles as a validity check.
+
+The redirect also names the Gigya data centre (`fidm.<dc>.gigya.com`), which is
+what tells us whether a household's keys live on the EU or the AS REST backend.
+
+Run:
+  python tools/dump_map_countries.py            # print CONSUMER_CLIENT_IDS + GIGYA_DC
+  python tools/dump_map_countries.py --check    # diff against cloud.py, exit 1 on drift
+  python tools/dump_map_countries.py --cc au nz # probe specific countries only
+
+Verified 2026-08-22: all 18 countries that were extracted from the APK reproduce
+byte-for-byte through this probe, so the two sources agree where they overlap.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import re
+import sys
+import urllib.parse
+from pathlib import Path
+
+import aiohttp
+
+ROOT = Path(__file__).resolve().parent.parent
+
+MAP_HOST = "https://prod.map.miele-iot.com"
+REDIRECT_URI = "miele://oauth2-code/"
+
+# ISO 3166-1 alpha-2 codes worth probing. Miele runs sales companies in a subset;
+# unrecognised codes are simply skipped, so over-probing costs only a round trip.
+CANDIDATE_COUNTRIES = (
+    "ad ae ar at au be bg br ca ch cl cn co cy cz de dk ee eg es fi fr gb gr hk "
+    "hr hu id ie il in is it jp kr kw kz lt lu lv ma mx my nl no nz pe ph pl pt "
+    "qa ro rs ru sa se sg si sk th tr tw ua us vn za"
+).split()
+
+_GIGYA_RE = re.compile(r"fidm\.(?P<dc>[a-z0-9]+)\.gigya\.com")
+
+
+async def probe(session: aiohttp.ClientSession, cc: str) -> tuple[str, str, str] | None:
+    """Return (cc, gigya_dc, client_id), or None when MAP doesn't know `cc`."""
+    params = {
+        "client_id": "probe",  # deliberately bogus — MAP substitutes the real one
+        "response_type": "code",
+        "redirect_uri": REDIRECT_URI,
+        "scope": "openid",
+        "state": "probe",
+    }
+    url = f"{MAP_HOST}/{cc}/authorize?" + urllib.parse.urlencode(params)
+    async with session.get(
+        url, allow_redirects=False, timeout=aiohttp.ClientTimeout(total=15)
+    ) as r:
+        location = r.headers.get("Location")
+    if not location:
+        return None
+    dc_match = _GIGYA_RE.search(location)
+    client_id = urllib.parse.parse_qs(
+        urllib.parse.urlparse(location).query
+    ).get("client_id", [None])[0]
+    if not dc_match or not client_id:
+        return None
+    return cc, dc_match.group("dc"), client_id
+
+
+async def probe_all(countries: list[str]) -> list[tuple[str, str, str]]:
+    """Probe every country concurrently; drop the ones MAP doesn't recognise."""
+    sem = asyncio.Semaphore(8)  # be gentle with a third party's gateway
+
+    async def one(session: aiohttp.ClientSession, cc: str):
+        async with sem:
+            try:
+                return await probe(session, cc)
+            except Exception as err:  # noqa: BLE001
+                print(f"  ! {cc}: {err}", file=sys.stderr)
+                return None
+
+    # Force the stdlib resolver: aiohttp prefers aiodns when it is importable, and
+    # a Home Assistant venv can carry an aiodns/pycares pair that raises on every
+    # lookup. Nothing here needs an async resolver, so sidestep it entirely.
+    connector = aiohttp.TCPConnector(resolver=aiohttp.ThreadedResolver())
+    async with aiohttp.ClientSession(connector=connector) as session:
+        results = await asyncio.gather(*(one(session, cc) for cc in countries))
+    return sorted(r for r in results if r)
+
+
+def render(rows: list[tuple[str, str, str]]) -> str:
+    """Emit both tables in the exact shape `cloud.py` carries them."""
+    ids = "\n".join(f'    "{cc}": "{cid}",' for cc, _, cid in rows)
+    dcs = "\n".join(f'    "{cc}": "{dc}",' for cc, dc, _ in rows)
+    return (
+        f"CONSUMER_CLIENT_IDS: dict[str, str] = {{\n{ids}\n}}\n\n"
+        f"GIGYA_DC_BY_COUNTRY: dict[str, str] = {{\n{dcs}\n}}\n"
+    )
+
+
+def check(rows: list[tuple[str, str, str]]) -> int:
+    """Compare the live probe against the table currently in cloud.py."""
+    sys.path.insert(0, str(ROOT))
+    from custom_components.miele_lan.cloud import (  # noqa: E402
+        CONSUMER_CLIENT_IDS,
+        GIGYA_DC_BY_COUNTRY,
+    )
+
+    live_ids = {cc: cid for cc, _, cid in rows}
+    live_dcs = {cc: dc for cc, dc, _ in rows}
+    drift = 0
+    for cc, cid in sorted(live_ids.items()):
+        if cc not in CONSUMER_CLIENT_IDS:
+            print(f"MISSING  {cc}: MAP serves {cid}, cloud.py has no entry")
+            drift += 1
+        elif CONSUMER_CLIENT_IDS[cc] != cid:
+            print(f"CHANGED  {cc}: cloud.py={CONSUMER_CLIENT_IDS[cc]} MAP={cid}")
+            drift += 1
+    for cc in sorted(set(CONSUMER_CLIENT_IDS) - set(live_ids)):
+        print(f"STALE    {cc}: in cloud.py but MAP no longer recognises it")
+        drift += 1
+    for cc, dc in sorted(live_dcs.items()):
+        if GIGYA_DC_BY_COUNTRY.get(cc) not in (None, dc):
+            print(f"DC MOVED {cc}: cloud.py={GIGYA_DC_BY_COUNTRY[cc]} MAP={dc}")
+            drift += 1
+    print(f"\n{len(live_ids)} countries served by MAP; {drift} discrepancies.")
+    return 1 if drift else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--cc", nargs="+", metavar="CC",
+        help="probe only these country codes (default: the built-in candidate list)",
+    )
+    parser.add_argument(
+        "--check", action="store_true",
+        help="diff the probe against cloud.py and exit non-zero on drift",
+    )
+    args = parser.parse_args()
+
+    countries = [c.lower() for c in (args.cc or CANDIDATE_COUNTRIES)]
+    rows = asyncio.run(probe_all(countries))
+    if not rows:
+        print("no countries answered — network blocked, or MAP changed shape?",
+              file=sys.stderr)
+        return 2
+    if args.check:
+        return check(rows)
+    print(render(rows))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/miele_lan_provision.py
+++ b/tools/miele_lan_provision.py
@@ -203,7 +203,7 @@ async def _fetch_cloud_tan(tokens_path: Path) -> str:
             try: tokens_path.chmod(0o600)
             except Exception: pass
             print(f"  (refresh_token rotated; saved → {tokens_path})")
-        return await fetch_pairing_tan(session, access_token, region="EU")
+        return await fetch_pairing_tan(session, access_token, cc=cc)
 
 
 async def _send_tan_to_appliance(


### PR DESCRIPTION
Thanks for the go-ahead on #6.

Cloud pairing currently works only for the sales companies whose consumer `client_id` is hard-coded, so users elsewhere cannot complete setup. This adds the remaining regions, plus several related failure modes found while testing against a live account.

Closes #6 — four people there so far (`sg`, `be`, `au`, `lv`).

### What changed

- **All 49 sales companies Miele's MAP gateway serves**, rather than the 18 originally taken from the APK.
- **The gateway hands the values out itself.** `GET prod.map.miele-iot.com/{cc}/authorize` with any junk `client_id` answers `302`, and the `Location` carries the real one — MAP rewrites whatever you send. All 18 existing values reproduce byte-for-byte through this probe, so the two sources agree everywhere they overlap.
- **`tools/dump_map_countries.py`** regenerates the table, and `--check` diffs it against `cloud.py` and exits non-zero if Miele ever changes anything, so it need not go stale.
- **The Gigya data centre does not predict the REST backend.** An `au` account authenticates against `au1`, but its household lives on `rest-eu` — while `rest-as` answers for the same account with an unrelated *empty* household. `fetch_groupkey` now tries every backend and prefers the household mDNS can actually see, rather than trusting the first answer.
- **Distinguishes "this account owns a different household" from "no appliance answered mDNS"**, which previously produced the same error and sent me chasing a network fault that did not exist.
- Keeps `Accept-Language` on the cloud calls, and lets the mDNS fallback run when the cloud lists no devices.

### Testing

284 lines of new tests in `tests/test_cloud_regions.py`, all offline — 51 pass in total. Verified end to end against a live Australian account with three appliances.

### Notes

- **No `manifest.json` version bump**, so it will not conflict if you squash — take whatever version you prefer.
- #9 adds `lt` independently, with a value byte-identical to the one this produces — good corroboration from a second source. Credit to @v-rejected.
- #11 adds `be`, which this also covers. Credit to @kristoffeys.

Happy to reshape any of it — split it up, squash it, rename things to match your conventions. Just say.
