### PR TITLE
fix: mobile_start read the wrong RemoteEnable element

### DIFF
--- a/custom_components/miele_lan/binary_sensor.py
+++ b/custom_components/miele_lan/binary_sensor.py
@@ -125,13 +125,17 @@ BINARY_SENSOR_TYPES: tuple[MieleLanBinarySensorDef, ...] = (
             is_on_fn=lambda s: s.get("Status") == 5,
         ),
     ),
-    # Mobile-start enabled (RemoteEnable[0] == 15) — devices that can be remote-started
+    # /State RemoteEnable is [fullRemoteControl, smartGrid, mobileStart] — the
+    # same triple, in the same order, that the cloud API exposes as
+    # remoteEnable.{fullRemoteControl,smartGrid,mobileStart}. Verified against a
+    # live WER875 reporting [15, 1, 0] while the cloud reported
+    # fullRemoteControl=on, smartGrid=on, mobileStart=off.
     MieleLanBinarySensorDef(
         types=CYCLE_FAMILY,
         description=MieleLanBinarySensorDescription(
             key="mobile_start",
             translation_key="mobile_start",
-            is_on_fn=lambda s: (s.get("RemoteEnable") or [0])[0] == 15,  # type: ignore[index]
+            is_on_fn=lambda s: bool((s.get("RemoteEnable") or [0, 0, 0])[2]),  # type: ignore[index]
         ),
     ),
     # SuperCool — fridges. Read-only on LAN by firmware policy on K7000


### PR DESCRIPTION
## Problem

The `mobile_start` binary sensor reads the wrong element of `/State`'s `RemoteEnable`
array, so it reports "on" whenever **full remote control** is enabled — not when
mobile start is.

`RemoteEnable` is a three-element array `[fullRemoteControl, smartGrid, mobileStart]`,
the same triple (and order) the Miele cloud API exposes as
`remoteEnable.{fullRemoteControl, smartGrid, mobileStart}`. The sensor tested
`RemoteEnable[0] == 15`, which is `fullRemoteControl`.

## Fix

Read element `2` (`mobileStart`) instead, as a boolean.

```python
is_on_fn=lambda s: bool((s.get("RemoteEnable") or [0, 0, 0])[2])
```

## Verification

On a live **Miele WER875 WPS** the appliance reported `RemoteEnable: [15, 1, 0]`.
At the same moment the official Home Assistant cloud integration reported, for the
same appliance:

| field | cloud | this array |
|---|---|---|
| `fullRemoteControl` | on | `[0] = 15` |
| `smartGrid` | on | `[1] = 1` |
| `mobileStart` | **off** | `[2] = 0` |

Before the fix the sensor showed `on`; after, it shows `off`, matching the cloud.

Scope is one line plus a clarifying comment; no other behaviour changes.
