### PR TITLE
ci: Automate releases with semantic-release and credit contributors

### DIFF
--- a/.github/scripts/release-contributors.sh
+++ b/.github/scripts/release-contributors.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Append a "Contributors" section to a published GitHub release.
+#
+# Credits every GitHub account whose commits landed in the release, as an
+# @mention, except the repository owner and bot accounts. Squash-merging a PR
+# keeps the contributor as the commit author, so the commit -> account lookup
+# is what makes this accurate; parsing "(#123)" out of subjects would miss
+# commits landed any other way.
+set -euo pipefail
+
+VERSION="${1:?usage: release-contributors.sh <version>}"
+TAG="v${VERSION}"
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+OWNER="${GITHUB_REPOSITORY_OWNER:?GITHUB_REPOSITORY_OWNER is required}"
+
+git fetch --tags --quiet
+
+PREV_TAG="$(git tag --list 'v*' --sort=-v:refname | grep -vFx "$TAG" | head -n1 || true)"
+if [ -n "$PREV_TAG" ]; then
+  RANGE="${PREV_TAG}..${TAG}"
+else
+  RANGE="$TAG"
+fi
+echo "Collecting contributors over ${RANGE}"
+
+logins=""
+while read -r sha; do
+  [ -n "$sha" ] || continue
+  # The commit author is only linked to an account when the commit email belongs
+  # to one. It often does not, so fall back to the author of the pull request the
+  # commit came from before giving up on crediting someone.
+  login="$(gh api "repos/${REPO}/commits/${sha}" --jq '.author.login // empty' 2>/dev/null || true)"
+  if [ -z "$login" ]; then
+    login="$(gh api "repos/${REPO}/commits/${sha}/pulls" --jq 'first(.[].user.login) // empty' 2>/dev/null || true)"
+  fi
+  [ -n "$login" ] || continue
+  logins="${logins}${login}"$'\n'
+done < <(git rev-list "$RANGE")
+
+# Drop the owner and any bot account; semantic-release's own release commit is
+# authored by a bot and must not show up as a contributor.
+credited="$(printf '%s' "$logins" \
+  | sed '/^$/d' \
+  | sort -u \
+  | grep -vix "$OWNER" \
+  | grep -vixE 'semantic-release-bot|dependabot|.*\[bot\]' || true)"
+
+if [ -z "$credited" ]; then
+  echo "No external contributors in ${TAG} — release notes left unchanged."
+  exit 0
+fi
+
+body_file="$(mktemp)"
+gh release view "$TAG" --repo "$REPO" --json body --jq .body > "$body_file"
+{
+  printf '\n### Contributors\n\n'
+  printf 'Thanks to everyone whose work is part of this release:\n\n'
+  printf '* @%s\n' $credited
+} >> "$body_file"
+
+gh release edit "$TAG" --repo "$REPO" --notes-file "$body_file"
+echo "Credited: $(printf '%s ' $credited)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,69 +1,74 @@
 name: Release
 
+# Conventional-commit driven releases via semantic-release.
+#   push to `main` → analyse commits → bump manifest.json → tag vX.Y.Z → GitHub release
+# Only feat / fix / perf / revert commits cut a release; ci, chore, docs and test
+# commits ride along in the notes of the next one. A release is only cut when the
+# test gate below is green, so a broken commit cannot reach HACS users.
+#
+# The release commit carries [skip ci], so writing manifest.json back to main
+# does not trigger this workflow again.
+
 on:
   push:
-    tags:
-      - "v*.*.*"
+    branches:
+      - main
   workflow_dispatch:
-    inputs:
-      tag:
-        description: "Tag to release (e.g. v1.0.0)"
-        required: true
+
+# Never run two releases on the same branch concurrently.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   release:
-    name: Publish GitHub Release
+    name: Test gate + semantic-release
     runs-on: ubuntu-latest
     steps:
-      - name: Resolve ref
-        id: ref
-        env:
-          INPUT_TAG: ${{ inputs.tag }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "ref=$INPUT_TAG" >> "$GITHUB_OUTPUT"
-            echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=$GITHUB_REF" >> "$GITHUB_OUTPUT"
-            echo "tag=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: actions/checkout@v5
         with:
-          ref: ${{ steps.ref.outputs.ref }}
+          fetch-depth: 0 # semantic-release needs full history + tags
 
-      - name: Verify manifest version matches tag
-        env:
-          TAG: ${{ steps.ref.outputs.tag }}
-        run: |
-          TAG_VERSION="${TAG#v}"
-          MANIFEST_VERSION=$(jq -r '.version' custom_components/miele_lan/manifest.json)
-          if [ "$TAG_VERSION" != "$MANIFEST_VERSION" ]; then
-            echo "::error::Tag $TAG (=> $TAG_VERSION) does not match manifest.json version $MANIFEST_VERSION"
-            exit 1
-          fi
-          echo "OK: tag $TAG matches manifest version $MANIFEST_VERSION"
-
-      - name: Detect prerelease
-        id: meta
-        env:
-          TAG: ${{ steps.ref.outputs.tag }}
-        run: |
-          if printf '%s' "$TAG" | grep -q -- '-'; then
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+      # ---- Test gate: a broken commit must not cut a release ----
+      - uses: actions/setup-python@v6
         with:
-          tag_name: ${{ steps.ref.outputs.tag }}
-          name: ${{ steps.ref.outputs.tag }}
-          generate_release_notes: true
-          draft: false
-          prerelease: ${{ steps.meta.outputs.prerelease }}
+          python-version: "3.13"
+      - run: pip install -q homeassistant asyncmiele==0.2.6 pytest pytest-asyncio pyyaml
+      - run: pytest tests/ -q
+      # -----------------------------------------------------------
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24" # semantic-release@25 needs >=24.10
+
+      # EXACT pins, not major ranges: the plugins and the conventional-changelog
+      # packages are only compatible in specific combinations, and a floating
+      # range can resolve an incompatible pair that fails *after* the version has
+      # been computed. Bump these deliberately, together, and watch the first
+      # release afterwards.
+      - name: Run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          npx --yes
+          --package semantic-release@25.0.9
+          --package @semantic-release/exec@7.1.0
+          --package @semantic-release/git@10.0.1
+          --package conventional-changelog-conventionalcommits@10.3.0
+          semantic-release
+
+      # semantic-release writes release.env only when it actually published.
+      - name: Credit contributors in the release notes
+        if: hashFiles('release.env') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -a
+          . ./release.env
+          set +a
+          bash .github/scripts/release-contributors.sh "$VERSION_NUMBER"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,53 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "perf", "section": "Performance" },
+            { "type": "revert", "section": "Reverts" },
+            { "type": "refactor", "section": "Refactoring" },
+            { "type": "ci", "section": "Build & CI" },
+            { "type": "docs", "section": "Documentation" },
+            { "type": "chore", "hidden": true },
+            { "type": "test", "hidden": true },
+            { "type": "style", "hidden": true }
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "jq --indent 2 --arg v '${nextRelease.version}' '.version = $v' custom_components/miele_lan/manifest.json > manifest.tmp && mv manifest.tmp custom_components/miele_lan/manifest.json",
+        "successCmd": "echo 'VERSION_NUMBER=${nextRelease.version}' >> release.env"
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["custom_components/miele_lan/manifest.json"],
+        "message": "chore: Release v${nextRelease.version} [skip ci]"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "failComment": false
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
Replaces the manual "bump `manifest.json` → tag → push" release ritual with a conventional-commit driven release, and credits contributors by @mention in the notes.

## What changes

**Releases become automatic.** Pushing to `main` analyses the commits since the last tag and, when they warrant a release, bumps `custom_components/miele_lan/manifest.json`, commits it, tags `vX.Y.Z`, and publishes the GitHub release. No manual bump or tag any more.

- Only `feat` / `fix` / `perf` / `revert` cut a release. `ci`, `chore`, `docs` and `test` ride along in the notes of the next one, so CI housekeeping never ships a version to HACS users.
- Notes are grouped by Conventional Commit type (Features, Bug Fixes, Performance, …) instead of the flat list GitHub generated.
- The release commit carries `[skip ci]`, so writing the manifest back to `main` cannot loop.
- A test gate runs `pytest tests/ -q` first — the same command and dependency set `validate.yml` uses — so a broken commit cannot cut a release.

**Contributors get credited.** `.github/scripts/release-contributors.sh` appends a `### Contributors` section listing everyone whose commits are in the release as `@mentions`, excluding the repository owner and bot accounts.

Resolving an author is done in two steps, which matters: a commit only links to an account when its email belongs to one, and that often fails. Verified against the real v1.6.0…v1.7.0 range — `michael-dev`'s commit has an unlinked email and resolves only through its pull request, so a commit-author-only lookup would have silently dropped him:

```
### Contributors

Thanks to everyone whose work is part of this release:

* @michael-dev
* @stormshaker
```

## Verification

- `.releaserc.json` and the workflow YAML parse; the script passes `bash -n`.
- The `jq` manifest rewrite was run against the real `manifest.json`: only the `version` line changes, and the `domain`, `name`, then-alphabetical key order hassfest requires is preserved.
- The contributor lookup was dry-run over `v1.6.0..v1.7.0` and produced the block above.

## Notes

- The version-bump commit will be authored by `semantic-release-bot` rather than `tiehfood`; the script filters bot accounts so it never appears as a contributor.
- semantic-release pushes directly to `main`, which is currently unprotected. If branch protection is added later, this job needs an exception or a token that can bypass it.
- Merging this PR cuts no release — it is a `ci:` change by design.