### PR TITLE
fix: Decouple DOP2 write capability from the stats probe and fix the HTTP 500 message

### DIFF
--- a/custom_components/miele_lan/api.py
+++ b/custom_components/miele_lan/api.py
@@ -300,9 +300,13 @@ class MieleLanClient:
         """Send a GLOBAL_USER_REQ opcode via DOP2 leaf 2/1583.
 
         Works across oven, laundry, and dishwasher device classes.
-        The front-panel "Mobile controllable" setting must be on, else the device
-        returns HTTP 500. Some firmwares (e.g. EK057 FW 08.32) block all DOP2
-        writes unconditionally and return HTTP 404.
+        Some firmwares (e.g. EK057 FW 08.32) block all DOP2 writes
+        unconditionally and return HTTP 404. A 403 means the appliance
+        rejected the request as unauthorized (e.g. "Remote control" /
+        "Mobile controllable" disabled in its settings menu). A 500 is the
+        appliance failing to execute the command — it does not indicate a
+        settings problem; the appliance may be in a state that doesn't accept
+        this command right now, or this model may not support it locally.
         """
         payload = build_user_request_payload(opcode)
         resource = (
@@ -320,10 +324,16 @@ class MieleLanClient:
                     "This appliance's firmware does not accept remote commands "
                     "over the local API (DOP2 writes are blocked on this hardware/firmware)."
                 ) from exc
-            if status == 500:
+            if status == 403:
                 raise HomeAssistantError(
                     "Remote control was refused. Enable 'Remote control' / "
                     "'Mobile controllable' in the appliance's settings menu and try again."
+                ) from exc
+            if status == 500:
+                raise HomeAssistantError(
+                    "The appliance rejected the command (HTTP 500). This can happen "
+                    "if it isn't in a state that accepts it right now, or if this "
+                    "model doesn't support this command over the local API."
                 ) from exc
             raise HomeAssistantError(
                 f"Remote command failed (HTTP {status})."

--- a/custom_components/miele_lan/button.py
+++ b/custom_components/miele_lan/button.py
@@ -32,7 +32,6 @@ from .entity import MieleLanEntity
 @dataclass(frozen=True, kw_only=True)
 class MieleLanButtonDescription(ButtonEntityDescription):
     press_fn: Callable[[MieleLanClient], Awaitable[Any]]
-    requires_dop2: bool = False
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -47,7 +46,6 @@ BUTTONS: tuple[MieleLanButtonDef, ...] = (
         description=MieleLanButtonDescription(
             key="wake",
             translation_key="wake",
-            requires_dop2=False,
             press_fn=lambda c: c.wake(),
         ),
     ),
@@ -56,7 +54,6 @@ BUTTONS: tuple[MieleLanButtonDef, ...] = (
         description=MieleLanButtonDescription(
             key="stop_program",
             translation_key="stop_program",
-            requires_dop2=True,
             press_fn=lambda c: c.write_user_request(OPCODE_STOP),
         ),
     ),
@@ -75,8 +72,6 @@ async def async_setup_entry(
         dt = coord.device_type
         for d in BUTTONS:
             if dt not in d.types:
-                continue
-            if d.description.requires_dop2 and not coord.dop2_supported:
                 continue
             entities.append(MieleLanButton(coord, d.description))
     async_add_entities(entities)

--- a/custom_components/miele_lan/coordinator.py
+++ b/custom_components/miele_lan/coordinator.py
@@ -78,7 +78,7 @@ class MieleLanCoordinator(DataUpdateCoordinator[MieleLanData]):
         self._data = MieleLanData()
         self._ident_loaded = False
         self._dop2_last_fetch: float = 0.0
-        self._dop2_unsupported = False
+        self._hours_unsupported = False
         self._wlan_last_fetch: float = 0.0
         self._device_context_last_fetch: float = 0.0
         self._device_context_unsupported: bool = False
@@ -108,8 +108,15 @@ class MieleLanCoordinator(DataUpdateCoordinator[MieleLanData]):
         return MieleAppliance.UNKNOWN
 
     @property
-    def dop2_supported(self) -> bool:
-        return not self._dop2_unsupported
+    def hours_of_operation_supported(self) -> bool:
+        """Whether DOP2 leaf 2/119 (HoursOfOperation) answered 200 at least once.
+
+        This is a read-only statistics leaf and says nothing about whether
+        DOP2 *writes* (leaf 2/1583 — power, stop-program, etc.) work on this
+        appliance. The two are independent capabilities; do not use this flag
+        to gate control entities.
+        """
+        return not self._hours_unsupported
 
     # --------- diagnostic helpers (used by the diagnostic sensor) ---------
     @property
@@ -151,7 +158,7 @@ class MieleLanCoordinator(DataUpdateCoordinator[MieleLanData]):
                 self._data.ident = await self._fetch_full_ident()
                 self._ident_loaded = True
             await self._maybe_refresh_wlan()
-            await self._maybe_refresh_dop2()
+            await self._maybe_refresh_hours_of_operation()
             await self._maybe_refresh_device_context()
         except Exception as err:  # noqa: BLE001
             raise UpdateFailed(str(err)) from err
@@ -172,16 +179,22 @@ class MieleLanCoordinator(DataUpdateCoordinator[MieleLanData]):
             self._data.wlan = result
             self._wlan_last_fetch = now
 
-    async def _maybe_refresh_dop2(self) -> None:
-        """Refresh DOP2-sourced diagnostics for device types that expose them.
+    async def _maybe_refresh_hours_of_operation(self) -> None:
+        """Refresh the HoursOfOperation statistics leaf (DOP2 2/119) for ovens.
 
-        Today: HoursOfOperation (leaf 2/119) for ovens. The leaf only updates
-        when a program runs, so we throttle to DOP2_REFRESH_INTERVAL — much
-        slower than the /State poll. Some appliances (and many cloud-only
-        commissionings) return 404 here; we latch off after the first miss to
-        avoid a steady noise of failures in the log.
+        This is a read-only stats probe, unrelated to whether DOP2 *writes*
+        (power, stop-program — leaf 2/1583) work on this device; it must
+        never be used to gate control-entity creation.
+
+        The leaf only updates when a program runs, so we throttle to
+        DOP2_REFRESH_INTERVAL — much slower than the /State poll. A 403/404
+        is a genuine "this firmware doesn't expose this leaf" signal, so we
+        latch off after the first one to avoid steady log noise. Any other
+        failure (timeouts, 500s — seen on some FW 09.14 units) is treated as
+        transient and retried next cycle rather than latched, since it says
+        nothing about whether the leaf is actually supported.
         """
-        if self._dop2_unsupported:
+        if self._hours_unsupported:
             return
         if self.device_type not in OVEN_FAMILY:
             return
@@ -195,12 +208,12 @@ class MieleLanCoordinator(DataUpdateCoordinator[MieleLanData]):
                 allowed_status=(200, 403, 404),
             )
         except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("[%s] DOP2 2/119 fetch failed: %s", self.fab, err)
+            _LOGGER.debug("[%s] DOP2 2/119 fetch failed (transient, will retry): %s", self.fab, err)
             return
         if st != 200:
-            self._dop2_unsupported = True
+            self._hours_unsupported = True
             _LOGGER.debug(
-                "[%s] DOP2 2/119 returned %d — disabling DOP2 reads on this device",
+                "[%s] DOP2 2/119 returned %d — disabling hours-of-operation reads on this device",
                 self.fab, st,
             )
             return

--- a/custom_components/miele_lan/sensor.py
+++ b/custom_components/miele_lan/sensor.py
@@ -918,7 +918,7 @@ async def async_setup_entry(
         for d in DOP2_SENSORS:
             if dt not in d.types:
                 continue
-            if not coord.dop2_supported:
+            if not coord.hours_of_operation_supported:
                 continue
             rdk = d.description.required_dop2_key
             if rdk is not None and rdk not in coord.data.dop2:

--- a/custom_components/miele_lan/switch.py
+++ b/custom_components/miele_lan/switch.py
@@ -77,8 +77,6 @@ async def async_setup_entry(
     entities = []
     for coord in coordinators.values():
         dt = coord.device_type
-        if not coord.dop2_supported:
-            continue
         for d in SWITCH_TYPES:
             if dt in d.types:
                 entities.append(MieleLanSwitch(coord, d.description))

--- a/tests/test_write_user_request_errors.py
+++ b/tests/test_write_user_request_errors.py
@@ -1,0 +1,56 @@
+"""Pure-Python tests for write_user_request's HTTP-status -> error-message mapping.
+
+No HA, no network — the underlying client is a stub that raises ResponseError.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from asyncmiele.exceptions.network import ResponseError  # noqa: E402
+from homeassistant.exceptions import HomeAssistantError  # noqa: E402
+
+from custom_components.miele_lan.api import MieleLanClient  # noqa: E402
+from custom_components.miele_lan.const import OPCODE_SWITCH_OFF  # noqa: E402
+
+
+class _StubRawClient:
+    def __init__(self, status_code: int) -> None:
+        self._status_code = status_code
+
+    async def _request_bytes(self, *args, **kwargs):
+        raise ResponseError(self._status_code, "stub failure")
+
+
+def _write_user_request(status_code: int) -> str:
+    client = MieleLanClient(_StubRawClient(status_code), route="000000000000")
+    with pytest.raises(HomeAssistantError) as exc_info:
+        asyncio.run(client.write_user_request(OPCODE_SWITCH_OFF))
+    return str(exc_info.value)
+
+
+def test_404_reports_firmware_block() -> None:
+    message = _write_user_request(404)
+    assert "does not accept remote commands" in message
+
+
+def test_403_reports_remote_control_refused() -> None:
+    message = _write_user_request(403)
+    assert "Remote control was refused" in message
+
+
+def test_500_does_not_blame_a_setting() -> None:
+    message = _write_user_request(500)
+    assert "Remote control was refused" not in message
+    assert "Mobile controllable" not in message
+    assert "500" in message
+
+
+def test_other_status_reports_generic_failure() -> None:
+    message = _write_user_request(409)
+    assert "409" in message


### PR DESCRIPTION
Addresses #7. Part of #16.

Neither issue is auto-closed: #7 needs the reporter to confirm the switch now works on their H7670BM, and #16 asked for two things — the misleading message is fixed here, but why the dishwasher's DOP2 write is rejected is still open.

Two faces of the same weakness: the integration inferred whether an appliance accepts DOP2 *writes* from signals that do not carry that information.

## #7 — appliances silently lost their power switch

The power switch was only created when `coord.dop2_supported` was true, and that flag was set by probing **DOP2 leaf 2/119 (HoursOfOperation)** — a read-only *statistics* leaf. Power and stop-program go to a different leaf, **2/1583**. The two are independent capabilities, so an appliance that does not expose the stats leaf lost its power switch even when writes would have worked. That is the H7670BM in #7: light and wake only, while the reporter's other steam oven — which answers 2/119 — works fine.

The flag is now named `hours_of_operation_supported`, means only what it measures, and gates only the diagnostic stats sensor. Control entities are created from device-type family membership alone; whether a write works is discovered by attempting it and surfacing the real error.

The probe also latched itself off on *any* non-200. Only 403/404 — a genuine "this firmware does not expose this leaf" — latch now; timeouts and 500s are treated as transient and retried. That was previously working only by accident, via exception routing, on FW 09.14 units that answer 500 there.

## #16 — a misleading error sent users to a setting that was already correct

`write_user_request()` mapped **any** HTTP 500 to *"Remote control was refused. Enable 'Remote control' / 'Mobile controllable'…"*. The reporter hit it on a G7310 with `RemoteEnable` reporting full remote control, an awake appliance, and healthy push — and lost time in the settings menu before reading the log. The official Miele cloud integration powers the same appliance successfully, so the hardware does accept remote power commands.

The remote-control wording now belongs to **403**, where an authorization refusal actually makes sense. **500** says what is true:

> The appliance rejected the command (HTTP 500). This can happen if it isn't in a state that accepts it right now, or if this model doesn't support this command over the local API.

404 (firmware blocks DOP2 writes) and the generic fallback are unchanged. The docstring's claim that "'Mobile controllable' must be on, else HTTP 500" is removed — #16 is direct evidence it is false.

## Trade-off, stated plainly

An appliance whose firmware genuinely blocks DOP2 writes now shows a power switch that errors when pressed, instead of no switch at all. That is deliberate: the error is specific and actionable ("this firmware does not accept remote commands over the local API"), whereas the old behaviour silently hid the control and gave the user nothing to go on — and hid it for the wrong reason.

## Verification

- `pytest tests/ -q` → **55 passed** (51 existing + 4 new).
- New `tests/test_write_user_request_errors.py` stubs the raw client and asserts the 404/403/500/other mapping; the 500 case asserts the absence of the old wording, so the regression cannot come back unnoticed.
- Grepped the package: no `dop2_supported`, `requires_dop2`, `_dop2_unsupported` or `_maybe_refresh_dop2` references remain.
- `manifest.json`, `hacs.json`, `strings.json` and `translations/*.json` are untouched; the error strings are plain `HomeAssistantError` messages needing no translation keys, and the entity keys now reaching more devices already exist in all three.

## Not in scope

Powering appliances via `PUT /State` `DeviceAction` — the path the cloud integration appears to use — is left alone deliberately. It is unverified for these models and belongs in its own change; #16's reporter has offered to test.
