### PR TITLE
chore: Replace real appliance identifiers in comments and tests with placeholders

### DIFF
--- a/custom_components/miele_lan/coordinator.py
+++ b/custom_components/miele_lan/coordinator.py
@@ -275,7 +275,7 @@ class MieleLanCoordinator(DataUpdateCoordinator[MieleLanData]):
             )
             return
         # Resource as parsed from the encrypted body is the *peer's own* path
-        # (e.g. "/Devices/000192453012/State/"), not the dispatch-side suffix.
+        # (e.g. "/Devices/000000000000/State/"), not the dispatch-side suffix.
         # Classify by substring rather than prefix.
         merged = False
         res = event.resource or ""

--- a/custom_components/miele_lan/push_listener.py
+++ b/custom_components/miele_lan/push_listener.py
@@ -53,7 +53,7 @@ MIELE_CONTENT_TYPE = "application/vnd.miele.v1+json; charset=utf-8"
 class PushEvent:
     """One decoded SuperVision push from a peer appliance."""
 
-    peer_fab: str                 # the device that pushed (e.g. "000192453012")
+    peer_fab: str                 # the device that pushed (e.g. "000000000000")
     resource: str                 # "/State/", "/State/Light/", "/State/Status/", "/Ident/"
     content: dict[str, Any]       # decoded JSON payload (the "Content" field)
     host_name: str | None         # mDNS hostname the peer advertised in its push body

--- a/tests/test_api_oven_payload.py
+++ b/tests/test_api_oven_payload.py
@@ -55,7 +55,7 @@ def test_state_pad_alignment_round_trip() -> None:
     from custom_components.miele_lan.api import _pad_request_body
 
     for raw in (b'{"Light":1}', b'{"DeviceAction":2}',
-                b'{"Resource":"/Devices/000192453012/State/","Callback":"http://192.168.33.53:8765/event"}'):
+                b'{"Resource":"/Devices/000000000000/State/","Callback":"http://192.0.2.1:8765/event"}'):
         out = _pad_request_body(raw)
         assert len(out) % 16 == 0
         assert out.endswith(b"}")


### PR DESCRIPTION
A real appliance's fab number and a real LAN IP were sitting in two code comments and one test fixture. Neither grants access on its own — the GroupKey is what does, and that has never been committed — but they identify a specific household's hardware and do not belong in a public repository.

| Where | Was | Now |
|---|---|---|
| `coordinator.py` comment | a real fab number | `000000000000` |
| `push_listener.py` comment | a real fab number | `000000000000` |
| `test_api_oven_payload.py` fixture | a real fab number + a real `192.168.x.x` address | `000000000000` + `192.0.2.1` |

`192.0.2.1` is from the RFC 5737 documentation range, so it reads unambiguously as an example rather than as somebody's network.

Deliberately left alone: `192.168.1.1` in `tools/miele_lan_provision.py` is Miele's own SoftAP address during commissioning — a protocol constant, not personal data — and the hex payload constants are protocol fixtures.

This only changes comments and one test string; `pytest tests/ -q` passes unchanged (51). The values remain in git history, which would need a force-push to rewrite — not worth it for identifiers that confer no access.