### PR TITLE
feat(config): Add an options flow for static appliance IPs

### DIFF
--- a/custom_components/miele_lan/__init__.py
+++ b/custom_components/miele_lan/__init__.py
@@ -89,11 +89,15 @@ async def _setup_cloud(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     devices: list[dict[str, Any]] = list(entry.data.get(CONF_DEVICES) or [])
     ha_fab: str = entry.data[CONF_HA_FAB]
     ha_port: int = entry.data.get(CONF_HA_PORT, DEFAULT_HA_PUSH_PORT)
-    # Bootstrap fab→IP map from the direct-keys setup blob. mDNS results
-    # discovered below win over this on collision (a stale cached IP from
-    # config-flow time shouldn't beat what the appliance is announcing right
-    # now).
-    static_ips: dict[str, str] = entry.data.get(CONF_STATIC_IPS) or {}
+    # Bootstrap fab→IP map from the direct-keys setup blob, layered under
+    # whatever the user has since set via the options flow (Settings →
+    # Configure). mDNS results discovered below win over both on collision (a
+    # stale cached IP from config-flow time shouldn't beat what the appliance
+    # is announcing right now).
+    static_ips: dict[str, str] = {
+        **(entry.data.get(CONF_STATIC_IPS) or {}),
+        **(entry.options.get(CONF_STATIC_IPS) or {}),
+    }
 
     # HA's LAN-facing IP on the interface that routes toward the appliances.
     # If we know any appliance IP, route toward it (multi-homed boxes pick the
@@ -296,9 +300,15 @@ async def _setup_cloud(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass, _token_refresh_loop(hass, entry), name=f"{DOMAIN}_token_refresh"
         )
 
+    bundle["options_unsub"] = entry.add_update_listener(_async_options_updated)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = bundle
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
+
+async def _async_options_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Options flow changed the static-IP map — reload so it takes effect."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def _safe_stop_listener(listener: MielePushListener) -> None:
@@ -344,6 +354,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     bundle = hass.data[DOMAIN].pop(entry.entry_id, None)
     if bundle is None:
         return True
+    options_unsub = bundle.get("options_unsub")
+    if options_unsub is not None:
+        options_unsub()
     task = bundle.get("token_refresh_task")
     if task is not None:
         task.cancel()
@@ -370,7 +383,10 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     group_id = entry.data.get(CONF_GROUP_ID)
     group_key = entry.data.get(CONF_GROUP_KEY)
     ha_fab = entry.data.get(CONF_HA_FAB)
-    static_ips = entry.data.get(CONF_STATIC_IPS) or {}
+    static_ips = {
+        **(entry.data.get(CONF_STATIC_IPS) or {}),
+        **(entry.options.get(CONF_STATIC_IPS) or {}),
+    }
     if not (group_id and group_key and ha_fab and static_ips):
         return
     import json as _json

--- a/custom_components/miele_lan/config_flow.py
+++ b/custom_components/miele_lan/config_flow.py
@@ -22,6 +22,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.const import CONF_HOST
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 
 from .api import MieleLanClient
@@ -34,6 +35,7 @@ from .cloud import (
     parse_redirect_url,
 )
 from .enrollment import mdns_discover_household, mdns_household_ids
+from .options_validation import merge_known_device_fields, parse_static_ip_lines
 from .const import (
     CONF_COUNTRY,
     CONF_DEVICES,
@@ -44,9 +46,11 @@ from .const import (
     CONF_REFRESH_TOKEN,
     CONF_REGION,
     CONF_ROUTE,
+    CONF_STATIC_IPS,
     DEFAULT_HA_PUSH_PORT,
     DEFAULT_NAME,
     DOMAIN,
+    STATIC_IPS_TEXT_FIELD,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -87,6 +91,14 @@ class MieleLanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # Cloud path
         self._challenge: PKCEChallenge | None = None
         self._authorize_url: str | None = None
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> MieleLanOptionsFlow:
+        """Static IPs for households whose mDNS/multicast doesn't reach HA."""
+        return MieleLanOptionsFlow()
 
     # --------------------------------------------------------------- entrypoint
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
@@ -415,4 +427,99 @@ class MieleLanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 "group_id": getattr(self, "_discovered_group_id", "") or "?",
                 "fab": getattr(self, "_discovered_fab", "") or "(unknown)",
             },
+        )
+
+
+class MieleLanOptionsFlow(config_entries.OptionsFlow):
+    """Static fabNr -> IP overrides for households whose mDNS/multicast
+    doesn't reach HA. See issue #14."""
+
+    def _current_static_ips(self) -> dict[str, str]:
+        return {
+            **(self.config_entry.data.get(CONF_STATIC_IPS) or {}),
+            **(self.config_entry.options.get(CONF_STATIC_IPS) or {}),
+        }
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        devices: list[dict[str, Any]] = list(
+            self.config_entry.data.get(CONF_DEVICES) or []
+        )
+        if devices:
+            return await self.async_step_known_devices()
+        return await self.async_step_freeform()
+
+    async def async_step_known_devices(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """One optional field per known appliance, keyed by its fab number."""
+        devices: list[dict[str, Any]] = list(
+            self.config_entry.data.get(CONF_DEVICES) or []
+        )
+        current = self._current_static_ips()
+        names = {
+            d["fabNr"]: d.get("deviceName") or ""
+            for d in devices
+            if d.get("fabNr")
+        }
+        fabs = sorted(names)
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            submitted = {fab: user_input.get(fab, "") for fab in fabs}
+            new_static, invalid = merge_known_device_fields(current, submitted)
+            if invalid:
+                errors["base"] = "invalid_static_ip"
+            else:
+                return self.async_create_entry(
+                    title="", data={CONF_STATIC_IPS: new_static}
+                )
+        return self.async_show_form(
+            step_id="known_devices",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        fab, description={"suggested_value": current.get(fab, "")}
+                    ): str
+                    for fab in fabs
+                }
+            ),
+            errors=errors,
+            description_placeholders={
+                "devices": ", ".join(
+                    f"`{fab}`" + (f" ({names[fab]})" if names[fab] else "")
+                    for fab in fabs
+                )
+            },
+        )
+
+    async def async_step_freeform(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """No known devices yet — the household's cloud/mDNS discovery never
+        ran. Accept `fabNr=IP` pairs, one per line, instead."""
+        current = self._current_static_ips()
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            mapping, bad_lines = parse_static_ip_lines(
+                user_input.get(STATIC_IPS_TEXT_FIELD, "")
+            )
+            if bad_lines:
+                errors["base"] = "invalid_static_ip"
+            else:
+                return self.async_create_entry(
+                    title="", data={CONF_STATIC_IPS: mapping}
+                )
+        default_text = "\n".join(f"{fab}={ip}" for fab, ip in sorted(current.items()))
+        return self.async_show_form(
+            step_id="freeform",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        STATIC_IPS_TEXT_FIELD,
+                        description={"suggested_value": default_text},
+                    ): str
+                }
+            ),
+            errors=errors,
         )

--- a/custom_components/miele_lan/const.py
+++ b/custom_components/miele_lan/const.py
@@ -36,6 +36,7 @@ CONF_DEVICES = "devices"            # list[{fabNr, deviceType, deviceName}] from
 CONF_HA_FAB = "ha_fab"              # our synthetic fab number
 CONF_HA_PORT = "ha_port"            # which unprivileged port our listener uses
 CONF_STATIC_IPS = "static_ips"      # optional dict fab→ip for users whose mDNS is flaky
+STATIC_IPS_TEXT_FIELD = "static_ips_text"  # options-flow free-form fab=ip textarea field
 
 CONF_FLOW_KIND = "flow_kind"        # "cloud" vs "manual" (single-device legacy path)
 DEFAULT_HA_PUSH_PORT = 18082

--- a/custom_components/miele_lan/options_validation.py
+++ b/custom_components/miele_lan/options_validation.py
@@ -1,0 +1,71 @@
+"""Pure parsing/validation for the static-IP options flow.
+
+No Home Assistant imports on purpose — this module is exercised directly by
+`tests/test_options_validation.py` without pulling in `homeassistant`.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+FAB_LENGTH = 12
+
+
+def is_valid_fab(fab: str) -> bool:
+    return len(fab) == FAB_LENGTH and fab.isdigit()
+
+
+def is_valid_ipv4(value: str) -> bool:
+    try:
+        ipaddress.IPv4Address(value)
+    except ValueError:
+        return False
+    return True
+
+
+def merge_known_device_fields(
+    current: dict[str, str], submitted: dict[str, str]
+) -> tuple[dict[str, str], list[str]]:
+    """Merge per-device options-form fields into `current`.
+
+    `submitted` maps fabNr -> the raw string the user typed for that
+    appliance's field. An empty/whitespace-only value clears that fab's
+    entry. Returns `(new_mapping, invalid_fabs)` — fabs whose value failed
+    IPv4 validation are left untouched in the result and reported back so the
+    caller can show a form error.
+    """
+    result = dict(current)
+    invalid: list[str] = []
+    for fab, value in submitted.items():
+        value = (value or "").strip()
+        if not value:
+            result.pop(fab, None)
+            continue
+        if not is_valid_ipv4(value):
+            invalid.append(fab)
+            continue
+        result[fab] = value
+    return result, invalid
+
+
+def parse_static_ip_lines(text: str) -> tuple[dict[str, str], list[str]]:
+    """Parse free-form `fabNr=IP` pairs, one per line.
+
+    Blank lines are ignored. Returns `(mapping, bad_lines)` — lines that
+    aren't `<12-digit fab>=<IPv4>` are reported back verbatim so the caller
+    can show a form error.
+    """
+    mapping: dict[str, str] = {}
+    bad_lines: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        fab, sep, ip = line.partition("=")
+        fab = fab.strip()
+        ip = ip.strip()
+        if not sep or not is_valid_fab(fab) or not is_valid_ipv4(ip):
+            bad_lines.append(line)
+            continue
+        mapping[fab] = ip
+    return mapping, bad_lines

--- a/custom_components/miele_lan/strings.json
+++ b/custom_components/miele_lan/strings.json
@@ -65,6 +65,24 @@
       "reloaded": "Reloading the integration — the new device will be picked up automatically."
     }
   },
+  "options": {
+    "step": {
+      "known_devices": {
+        "title": "Miele@LAN — static IPs",
+        "description": "Only needed if your network blocks mDNS/multicast between Home Assistant and the appliances (VLANs, IGMP snooping, an access point that filters mDNS). Enter an IPv4 address for an appliance to pin it, or leave a field blank to fall back to automatic discovery. Known appliances in this household: {devices}"
+      },
+      "freeform": {
+        "title": "Miele@LAN — static IPs",
+        "description": "Only needed if your network blocks mDNS/multicast between Home Assistant and the appliances (VLANs, IGMP snooping, an access point that filters mDNS). This household has no known appliances yet, so list them manually below.",
+        "data_description": {
+          "static_ips_text": "One `fabNr=IP` pair per line, e.g. `000000000000=192.0.2.1`. Leave a line out to fall back to automatic discovery for that appliance."
+        }
+      }
+    },
+    "error": {
+      "invalid_static_ip": "One or more entries are invalid — the fab number must be 12 digits and the address a valid IPv4 address."
+    }
+  },
   "entity": {
     "sensor": {
       "status": {

--- a/custom_components/miele_lan/strings.json
+++ b/custom_components/miele_lan/strings.json
@@ -74,6 +74,9 @@
       "freeform": {
         "title": "Miele@LAN — static IPs",
         "description": "Only needed if your network blocks mDNS/multicast between Home Assistant and the appliances (VLANs, IGMP snooping, an access point that filters mDNS). This household has no known appliances yet, so list them manually below.",
+        "data": {
+          "static_ips_text": "Static IP addresses"
+        },
         "data_description": {
           "static_ips_text": "One `fabNr=IP` pair per line, e.g. `000000000000=192.0.2.1`. Leave a line out to fall back to automatic discovery for that appliance."
         }

--- a/custom_components/miele_lan/translations/de.json
+++ b/custom_components/miele_lan/translations/de.json
@@ -66,6 +66,24 @@
       "reloaded": "Konfiguration wird neu geladen, neues Geraet wird automatisch erkannt."
     }
   },
+  "options": {
+    "step": {
+      "known_devices": {
+        "title": "Miele@LAN — Statische IPs",
+        "description": "Nur nötig, wenn dein Netzwerk mDNS/Multicast zwischen Home Assistant und den Geräten blockiert (VLANs, IGMP-Snooping, ein Access Point, der mDNS filtert). Für ein Gerät eine IPv4-Adresse eintragen, um sie festzulegen, oder ein Feld leer lassen, um zur automatischen Erkennung zurückzukehren. Bekannte Geräte in diesem Haushalt: {devices}"
+      },
+      "freeform": {
+        "title": "Miele@LAN — Statische IPs",
+        "description": "Nur nötig, wenn dein Netzwerk mDNS/Multicast zwischen Home Assistant und den Geräten blockiert (VLANs, IGMP-Snooping, ein Access Point, der mDNS filtert). Für diesen Haushalt sind noch keine Geräte bekannt — bitte unten manuell eintragen.",
+        "data_description": {
+          "static_ips_text": "Ein `fabNr=IP`-Paar pro Zeile, z. B. `000000000000=192.0.2.1`. Eine Zeile weglassen, um für dieses Gerät zur automatischen Erkennung zurückzukehren."
+        }
+      }
+    },
+    "error": {
+      "invalid_static_ip": "Ein oder mehrere Einträge sind ungültig — die Fabriknummer muss 12-stellig sein und die Adresse eine gültige IPv4-Adresse."
+    }
+  },
   "entity": {
     "sensor": {
       "status": {

--- a/custom_components/miele_lan/translations/de.json
+++ b/custom_components/miele_lan/translations/de.json
@@ -75,6 +75,9 @@
       "freeform": {
         "title": "Miele@LAN — Statische IPs",
         "description": "Nur nötig, wenn dein Netzwerk mDNS/Multicast zwischen Home Assistant und den Geräten blockiert (VLANs, IGMP-Snooping, ein Access Point, der mDNS filtert). Für diesen Haushalt sind noch keine Geräte bekannt — bitte unten manuell eintragen.",
+        "data": {
+          "static_ips_text": "Statische IP-Adressen"
+        },
         "data_description": {
           "static_ips_text": "Ein `fabNr=IP`-Paar pro Zeile, z. B. `000000000000=192.0.2.1`. Eine Zeile weglassen, um für dieses Gerät zur automatischen Erkennung zurückzukehren."
         }

--- a/custom_components/miele_lan/translations/en.json
+++ b/custom_components/miele_lan/translations/en.json
@@ -65,6 +65,24 @@
       "reloaded": "Reloading the integration — the new device will be picked up automatically."
     }
   },
+  "options": {
+    "step": {
+      "known_devices": {
+        "title": "Miele@LAN — static IPs",
+        "description": "Only needed if your network blocks mDNS/multicast between Home Assistant and the appliances (VLANs, IGMP snooping, an access point that filters mDNS). Enter an IPv4 address for an appliance to pin it, or leave a field blank to fall back to automatic discovery. Known appliances in this household: {devices}"
+      },
+      "freeform": {
+        "title": "Miele@LAN — static IPs",
+        "description": "Only needed if your network blocks mDNS/multicast between Home Assistant and the appliances (VLANs, IGMP snooping, an access point that filters mDNS). This household has no known appliances yet, so list them manually below.",
+        "data_description": {
+          "static_ips_text": "One `fabNr=IP` pair per line, e.g. `000000000000=192.0.2.1`. Leave a line out to fall back to automatic discovery for that appliance."
+        }
+      }
+    },
+    "error": {
+      "invalid_static_ip": "One or more entries are invalid — the fab number must be 12 digits and the address a valid IPv4 address."
+    }
+  },
   "entity": {
     "sensor": {
       "status": {

--- a/custom_components/miele_lan/translations/en.json
+++ b/custom_components/miele_lan/translations/en.json
@@ -74,6 +74,9 @@
       "freeform": {
         "title": "Miele@LAN — static IPs",
         "description": "Only needed if your network blocks mDNS/multicast between Home Assistant and the appliances (VLANs, IGMP snooping, an access point that filters mDNS). This household has no known appliances yet, so list them manually below.",
+        "data": {
+          "static_ips_text": "Static IP addresses"
+        },
         "data_description": {
           "static_ips_text": "One `fabNr=IP` pair per line, e.g. `000000000000=192.0.2.1`. Leave a line out to fall back to automatic discovery for that appliance."
         }

--- a/tests/test_options_validation.py
+++ b/tests/test_options_validation.py
@@ -1,0 +1,150 @@
+"""Tests for the static-IP options-flow parsing/validation.
+
+`options_validation.py` is loaded straight off disk, same as `cloud.py` in
+test_cloud_regions.py — it has zero relative imports, so this stays free of
+any `homeassistant` dependency.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "miele_lan_options_validation",
+    ROOT / "custom_components" / "miele_lan" / "options_validation.py",
+)
+ov = importlib.util.module_from_spec(_spec)
+sys.modules["miele_lan_options_validation"] = ov
+_spec.loader.exec_module(ov)
+
+
+FAB = "000000000000"
+OTHER_FAB = "000000000001"
+IP = "192.0.2.1"
+OTHER_IP = "192.0.2.2"
+
+
+# --------------------------------------------------------------- is_valid_fab
+def test_valid_fab_is_twelve_digits() -> None:
+    assert ov.is_valid_fab(FAB) is True
+
+
+def test_fab_too_short_is_invalid() -> None:
+    assert ov.is_valid_fab("123") is False
+
+
+def test_fab_too_long_is_invalid() -> None:
+    assert ov.is_valid_fab(FAB + "9") is False
+
+
+def test_fab_with_non_digits_is_invalid() -> None:
+    assert ov.is_valid_fab("00000000000a") is False
+
+
+# -------------------------------------------------------------- is_valid_ipv4
+def test_valid_ipv4_accepted() -> None:
+    assert ov.is_valid_ipv4(IP) is True
+
+
+def test_ipv6_is_rejected() -> None:
+    assert ov.is_valid_ipv4("::1") is False
+
+
+def test_garbage_is_rejected() -> None:
+    assert ov.is_valid_ipv4("not-an-ip") is False
+
+
+def test_out_of_range_octet_is_rejected() -> None:
+    assert ov.is_valid_ipv4("192.0.2.999") is False
+
+
+# ------------------------------------------------------ merge_known_device_fields
+def test_merge_sets_a_new_ip() -> None:
+    new, invalid = ov.merge_known_device_fields({}, {FAB: IP})
+    assert new == {FAB: IP}
+    assert invalid == []
+
+
+def test_merge_changes_an_existing_ip() -> None:
+    new, invalid = ov.merge_known_device_fields({FAB: IP}, {FAB: OTHER_IP})
+    assert new == {FAB: OTHER_IP}
+    assert invalid == []
+
+
+def test_merge_clears_on_blank_value() -> None:
+    new, invalid = ov.merge_known_device_fields({FAB: IP}, {FAB: ""})
+    assert new == {}
+    assert invalid == []
+
+
+def test_merge_clears_on_whitespace_only_value() -> None:
+    new, invalid = ov.merge_known_device_fields({FAB: IP}, {FAB: "   "})
+    assert new == {}
+    assert invalid == []
+
+
+def test_merge_rejects_invalid_ip_and_leaves_it_untouched() -> None:
+    new, invalid = ov.merge_known_device_fields({FAB: IP}, {FAB: "not-an-ip"})
+    assert new == {FAB: IP}
+    assert invalid == [FAB]
+
+
+def test_merge_leaves_untouched_fabs_alone() -> None:
+    new, invalid = ov.merge_known_device_fields(
+        {FAB: IP, OTHER_FAB: OTHER_IP}, {FAB: OTHER_IP}
+    )
+    assert new == {FAB: OTHER_IP, OTHER_FAB: OTHER_IP}
+    assert invalid == []
+
+
+# ------------------------------------------------------------ parse_static_ip_lines
+def test_parse_single_pair() -> None:
+    mapping, bad = ov.parse_static_ip_lines(f"{FAB}={IP}")
+    assert mapping == {FAB: IP}
+    assert bad == []
+
+
+def test_parse_multiple_pairs() -> None:
+    mapping, bad = ov.parse_static_ip_lines(f"{FAB}={IP}\n{OTHER_FAB}={OTHER_IP}")
+    assert mapping == {FAB: IP, OTHER_FAB: OTHER_IP}
+    assert bad == []
+
+
+def test_parse_ignores_blank_lines() -> None:
+    mapping, bad = ov.parse_static_ip_lines(f"\n{FAB}={IP}\n\n")
+    assert mapping == {FAB: IP}
+    assert bad == []
+
+
+def test_parse_strips_whitespace_around_pairs() -> None:
+    mapping, bad = ov.parse_static_ip_lines(f"  {FAB} = {IP}  ")
+    assert mapping == {FAB: IP}
+    assert bad == []
+
+
+def test_parse_rejects_line_without_equals() -> None:
+    mapping, bad = ov.parse_static_ip_lines(FAB)
+    assert mapping == {}
+    assert bad == [FAB]
+
+
+def test_parse_rejects_bad_fab() -> None:
+    line = f"123={IP}"
+    mapping, bad = ov.parse_static_ip_lines(line)
+    assert mapping == {}
+    assert bad == [line]
+
+
+def test_parse_rejects_bad_ip() -> None:
+    line = f"{FAB}=not-an-ip"
+    mapping, bad = ov.parse_static_ip_lines(line)
+    assert mapping == {}
+    assert bad == [line]
+
+
+def test_parse_empty_text_clears_everything() -> None:
+    mapping, bad = ov.parse_static_ip_lines("")
+    assert mapping == {}
+    assert bad == []


### PR DESCRIPTION
Closes #14.

`async_setup_entry` told users to "Configure static IPs in the integration's options if your network blocks mDNS/multicast", and a comment above it said the same. No options flow existed — `config_flow.py` defined only `MieleLanConfigFlow`, so the entry reported `supports_options: false` and Home Assistant showed no **Configure** button. The advice was impossible to follow.

Worse, the only code that ever *wrote* `CONF_STATIC_IPS` built it from `mdns_discover_household()` — the very mechanism that is broken in the situation the escape hatch exists for. On a network where multicast genuinely cannot be fixed (isolated IoT VLAN, IGMP snooping, an AP that filters mDNS) there was no path to a working setup at all.

## What this adds

An options flow that writes the `fabNr -> IP` map the runtime already consumes. Two shapes, because the interesting case is precisely the one where we know nothing:

- **Appliances known** — one optional IPv4 field per appliance, pre-filled with the current value, labelled with fab number and device name. Blank clears the pin and falls back to discovery.
- **No appliances known** — the actual #14 scenario, where discovery never populated anything — a free-form field taking `fabNr=IP`, one per line.

Where it is stored: `entry.options`, per Home Assistant convention. Both runtime read sites now layer options over the setup-time value from `data`, so options win while the original direct-keys seed still works for entries that never open the dialog. mDNS results continue to win over both, since a live announcement should beat a stale pin.

Changing the options reloads the entry through an update listener, so new addresses take effect without a restart; the listener is unsubscribed in `async_unload_entry`.

## Validation

Parsing and validation live in a new `options_validation.py` with no Home Assistant imports, so they are directly unit-testable: fab numbers must be 12 digits, addresses must parse as IPv4, and anything invalid re-renders the form with an error rather than raising or writing a partial map.

## Verification

- `pytest tests/ -q` → **77 passed** (55 existing + 22 new covering set/change/clear/invalid and line parsing, including whitespace and blank-line handling).
- `strings.json`, `translations/en.json` and `translations/de.json` carry the same 11 option keys — verified programmatically. German follows the file's existing informal tone.
- Examples in the strings use `000000000000` and `192.0.2.1` (RFC 5737), never real identifiers.
- `OptionsFlow` is constructed without arguments, which is correct for current Home Assistant: `config_entry` is an injected property and the class defines no `__init__` (checked against the HA version this repo tests with, 2026.2.3).

## Notes

- The `ConfigEntryNotReady` message is unchanged — it was already accurate, and is now true rather than aspirational.
- Per-device field *labels* fall back to the raw fab number in the frontend, since HA's static translation model has no way to name dynamically-generated fields. The step description lists `fab (name)` for each appliance to compensate.
- `hacs.json` declares no minimum Home Assistant version. The no-argument `OptionsFlow` pattern needs 2024.11 or newer, so adding a `homeassistant` key there may be worth doing separately — it would change what HACS offers to users on older cores, so I left it out of this PR.