### PR TITLE
feat(services): Add a read-only DOP2 leaf dump service

### DIFF
--- a/custom_components/miele_lan/__init__.py
+++ b/custom_components/miele_lan/__init__.py
@@ -52,6 +52,7 @@ from .push_listener import (
     detect_lan_ip,
     synthetic_mac_hostname,
 )
+from .services import async_remove_services, async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,6 +69,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Miele@LAN from a config entry. Both flow kinds (cloud OAuth and
     direct-keys with mDNS discovery) share the same runtime — one household
     entry, multi-device, push-first."""
+    async_setup_services(hass)
     flow_kind = entry.data.get("flow_kind", "cloud")
     if flow_kind == "manual":
         # Legacy v1 single-device entries from pre-0.3.0 installs. Migrate
@@ -351,6 +353,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if not unload_ok:
         return False
+    async_remove_services(hass)
     bundle = hass.data[DOMAIN].pop(entry.entry_id, None)
     if bundle is None:
         return True

--- a/custom_components/miele_lan/dop2_dump.py
+++ b/custom_components/miele_lan/dop2_dump.py
@@ -1,0 +1,24 @@
+"""Pure helpers for the `dump_dop2_leaf` debug service.
+
+No Home Assistant imports here — this module is exercised directly by
+tests/test_dop2_dump.py without booting HA.
+"""
+
+from __future__ import annotations
+
+# Every HTTP status a device might plausibly answer with. The dump service is
+# explicitly interested in the non-200 cases (403/404/500 tell a user whether
+# their firmware exposes a leaf at all), so nothing here should raise.
+ANY_HTTP_STATUS: tuple[int, ...] = tuple(range(100, 600))
+
+
+def build_dop2_resource(
+    fab: str, unit: int, attribute: int, idx1: int = 0, idx2: int = 0
+) -> str:
+    """Build the DOP2 leaf resource path, matching every other call site."""
+    return f"/Devices/{fab}/DOP2/{unit}/{attribute}?idx1={idx1}&idx2={idx2}"
+
+
+def bytes_to_hex(data: bytes) -> str:
+    """Lowercase hex dump of a leaf body, safe to paste into a GitHub issue."""
+    return data.hex()

--- a/custom_components/miele_lan/services.py
+++ b/custom_components/miele_lan/services.py
@@ -1,0 +1,124 @@
+"""Domain-level services for Miele@LAN.
+
+Registered once (guarded by `has_service`) from every `async_setup_entry`
+call and removed once `async_unload_entry` sees no loaded entries left —
+mirrors homeassistant.components.rainmachine's lifecycle so a reload of one
+household entry never drops the service out from under another.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from asyncmiele.exceptions.network import NetworkConnectionError, NetworkTimeoutError
+from homeassistant.core import HomeAssistant, ServiceCall, ServiceResponse, SupportsResponse, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, device_registry as dr
+
+from .const import DOMAIN
+from .dop2_dump import ANY_HTTP_STATUS, build_dop2_resource, bytes_to_hex
+
+_LOGGER = logging.getLogger(__name__)
+
+SERVICE_DUMP_DOP2_LEAF = "dump_dop2_leaf"
+
+ATTR_DEVICE_ID = "device_id"
+ATTR_UNIT = "unit"
+ATTR_ATTRIBUTE = "attribute"
+ATTR_IDX1 = "idx1"
+ATTR_IDX2 = "idx2"
+
+_DOP2_INDEX = vol.All(vol.Coerce(int), vol.Range(min=0, max=65535))
+
+DUMP_DOP2_LEAF_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): cv.string,
+        vol.Required(ATTR_UNIT): _DOP2_INDEX,
+        vol.Required(ATTR_ATTRIBUTE): _DOP2_INDEX,
+        vol.Optional(ATTR_IDX1, default=0): _DOP2_INDEX,
+        vol.Optional(ATTR_IDX2, default=0): _DOP2_INDEX,
+    }
+)
+
+
+def _resolve_fab(hass: HomeAssistant, device_id: str) -> str:
+    device_entry = dr.async_get(hass).async_get(device_id)
+    if device_entry is None:
+        raise HomeAssistantError(f"Unknown device_id: {device_id}")
+    fab = next(
+        (ident[1] for ident in device_entry.identifiers if ident[0] == DOMAIN), None
+    )
+    if fab is None:
+        raise HomeAssistantError("Selected device is not a Miele@LAN appliance")
+    return fab
+
+
+def _resolve_coordinator(hass: HomeAssistant, device_id: str, fab: str) -> Any:
+    device_entry = dr.async_get(hass).async_get(device_id)
+    for entry_id in device_entry.config_entries:
+        bundle = hass.data.get(DOMAIN, {}).get(entry_id)
+        if not bundle:
+            continue
+        coordinator = bundle.get("coordinators", {}).get(fab)
+        if coordinator is not None:
+            return coordinator
+    raise HomeAssistantError(
+        "This device has no active Miele@LAN connection right now — is the "
+        "integration entry loaded and the appliance reachable on the LAN?"
+    )
+
+
+async def _async_dump_dop2_leaf(call: ServiceCall) -> ServiceResponse:
+    """Read-only GET of a single DOP2 leaf; never writes, never raises on non-200."""
+    hass = call.hass
+    device_id = call.data[ATTR_DEVICE_ID]
+    unit = call.data[ATTR_UNIT]
+    attribute = call.data[ATTR_ATTRIBUTE]
+    idx1 = call.data[ATTR_IDX1]
+    idx2 = call.data[ATTR_IDX2]
+
+    fab = _resolve_fab(hass, device_id)
+    coordinator = _resolve_coordinator(hass, device_id, fab)
+
+    resource = build_dop2_resource(fab, unit, attribute, idx1, idx2)
+    try:
+        status, body = await coordinator.client.raw._request_bytes(
+            "GET", resource, allowed_status=ANY_HTTP_STATUS,
+        )
+    except (NetworkConnectionError, NetworkTimeoutError) as err:
+        raise HomeAssistantError(f"Could not reach the appliance: {err}") from err
+
+    return {
+        "unit": unit,
+        "attribute": attribute,
+        "idx1": idx1,
+        "idx2": idx2,
+        "status": status,
+        "length": len(body),
+        "hex": bytes_to_hex(body),
+    }
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register domain services once, regardless of how many entries call this."""
+    if hass.services.has_service(DOMAIN, SERVICE_DUMP_DOP2_LEAF):
+        return
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_DUMP_DOP2_LEAF,
+        _async_dump_dop2_leaf,
+        schema=DUMP_DOP2_LEAF_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+
+@callback
+def async_remove_services(hass: HomeAssistant) -> None:
+    """Drop domain services once the last config entry has unloaded."""
+    if hass.config_entries.async_loaded_entries(DOMAIN):
+        return
+    hass.services.async_remove(DOMAIN, SERVICE_DUMP_DOP2_LEAF)

--- a/custom_components/miele_lan/services.yaml
+++ b/custom_components/miele_lan/services.yaml
@@ -1,0 +1,39 @@
+dump_dop2_leaf:
+  fields:
+    device_id:
+      required: true
+      selector:
+        device:
+          integration: miele_lan
+    unit:
+      required: true
+      example: 2
+      selector:
+        number:
+          min: 0
+          max: 65535
+          mode: box
+    attribute:
+      required: true
+      example: 1585
+      selector:
+        number:
+          min: 0
+          max: 65535
+          mode: box
+    idx1:
+      required: false
+      example: 0
+      selector:
+        number:
+          min: 0
+          max: 65535
+          mode: box
+    idx2:
+      required: false
+      example: 0
+      selector:
+        number:
+          min: 0
+          max: 65535
+          mode: box

--- a/custom_components/miele_lan/strings.json
+++ b/custom_components/miele_lan/strings.json
@@ -2163,5 +2163,33 @@
         "name": "Stop program"
       }
     }
+  },
+  "services": {
+    "dump_dop2_leaf": {
+      "name": "Dump DOP2 leaf",
+      "description": "Reads one raw DOP2 leaf from an appliance and returns its bytes as hex. Read-only — never writes anything to the appliance. Useful for reporting undocumented data (consumables, sensor values) in a GitHub issue.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The Miele@LAN device to read from."
+        },
+        "unit": {
+          "name": "Unit",
+          "description": "DOP2 unit number, e.g. 2 or 14."
+        },
+        "attribute": {
+          "name": "Attribute",
+          "description": "DOP2 attribute (leaf) number within the unit, e.g. 1585."
+        },
+        "idx1": {
+          "name": "Index 1",
+          "description": "First DOP2 index parameter. Leave at 0 unless you know the leaf is indexed."
+        },
+        "idx2": {
+          "name": "Index 2",
+          "description": "Second DOP2 index parameter. Leave at 0 unless you know the leaf is indexed."
+        }
+      }
+    }
   }
 }

--- a/custom_components/miele_lan/translations/de.json
+++ b/custom_components/miele_lan/translations/de.json
@@ -2179,5 +2179,33 @@
         "name": "Programm stoppen"
       }
     }
+  },
+  "services": {
+    "dump_dop2_leaf": {
+      "name": "DOP2-Blatt auslesen",
+      "description": "Liest ein rohes DOP2-Blatt von einem Gerät aus und gibt die Bytes als Hex-String zurück. Rein lesend — schreibt niemals etwas auf das Gerät. Nützlich, um nicht dokumentierte Daten (Verbrauchsmaterial, Sensorwerte) in einem GitHub-Issue zu melden.",
+      "fields": {
+        "device_id": {
+          "name": "Gerät",
+          "description": "Das Miele@LAN-Gerät, von dem du lesen möchtest."
+        },
+        "unit": {
+          "name": "Unit",
+          "description": "DOP2-Unit-Nummer, z. B. 2 oder 14."
+        },
+        "attribute": {
+          "name": "Attribut",
+          "description": "DOP2-Attribut (Blatt) innerhalb der Unit, z. B. 1585."
+        },
+        "idx1": {
+          "name": "Index 1",
+          "description": "Erster DOP2-Indexparameter. Lass ihn bei 0, wenn du nicht weißt, dass das Blatt indiziert ist."
+        },
+        "idx2": {
+          "name": "Index 2",
+          "description": "Zweiter DOP2-Indexparameter. Lass ihn bei 0, wenn du nicht weißt, dass das Blatt indiziert ist."
+        }
+      }
+    }
   }
 }

--- a/custom_components/miele_lan/translations/en.json
+++ b/custom_components/miele_lan/translations/en.json
@@ -2169,5 +2169,33 @@
         "name": "Stop program"
       }
     }
+  },
+  "services": {
+    "dump_dop2_leaf": {
+      "name": "Dump DOP2 leaf",
+      "description": "Reads one raw DOP2 leaf from an appliance and returns its bytes as hex. Read-only — never writes anything to the appliance. Useful for reporting undocumented data (consumables, sensor values) in a GitHub issue.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The Miele@LAN device to read from."
+        },
+        "unit": {
+          "name": "Unit",
+          "description": "DOP2 unit number, e.g. 2 or 14."
+        },
+        "attribute": {
+          "name": "Attribute",
+          "description": "DOP2 attribute (leaf) number within the unit, e.g. 1585."
+        },
+        "idx1": {
+          "name": "Index 1",
+          "description": "First DOP2 index parameter. Leave at 0 unless you know the leaf is indexed."
+        },
+        "idx2": {
+          "name": "Index 2",
+          "description": "Second DOP2 index parameter. Leave at 0 unless you know the leaf is indexed."
+        }
+      }
+    }
   }
 }

--- a/tests/test_dop2_dump.py
+++ b/tests/test_dop2_dump.py
@@ -1,0 +1,83 @@
+"""Tests for the dump_dop2_leaf service's pure helpers and input schema.
+
+No live HA core object needed: dop2_dump.py has zero HA imports, and
+voluptuous schema validation runs standalone.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import voluptuous as vol
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from custom_components.miele_lan.dop2_dump import (  # noqa: E402
+    ANY_HTTP_STATUS,
+    build_dop2_resource,
+    bytes_to_hex,
+)
+from custom_components.miele_lan.services import (  # noqa: E402
+    ATTR_ATTRIBUTE,
+    ATTR_DEVICE_ID,
+    ATTR_IDX1,
+    ATTR_IDX2,
+    ATTR_UNIT,
+    DUMP_DOP2_LEAF_SCHEMA,
+)
+
+
+# ------------------------------------------------------------- resource path
+def test_build_dop2_resource_matches_existing_call_sites() -> None:
+    resource = build_dop2_resource("000000000000", 2, 1585)
+    assert resource == "/Devices/000000000000/DOP2/2/1585?idx1=0&idx2=0"
+
+
+def test_build_dop2_resource_with_explicit_indices() -> None:
+    resource = build_dop2_resource("000000000000", 2, 105, idx1=3, idx2=7)
+    assert resource == "/Devices/000000000000/DOP2/2/105?idx1=3&idx2=7"
+
+
+# --------------------------------------------------------------------- hex
+def test_bytes_to_hex_is_lowercase() -> None:
+    assert bytes_to_hex(b"\xAB\xCD\x01") == "abcd01"
+
+
+def test_bytes_to_hex_empty_body() -> None:
+    assert bytes_to_hex(b"") == ""
+
+
+# ------------------------------------------------------------ status range
+def test_any_http_status_covers_the_interesting_failure_codes() -> None:
+    for status in (200, 400, 403, 404, 500, 503):
+        assert status in ANY_HTTP_STATUS
+
+
+# ------------------------------------------------------------------ schema
+def test_schema_requires_device_id_unit_attribute() -> None:
+    with pytest.raises(vol.Invalid):
+        DUMP_DOP2_LEAF_SCHEMA({ATTR_UNIT: 2, ATTR_ATTRIBUTE: 1585})
+
+
+def test_schema_defaults_indices_to_zero() -> None:
+    result = DUMP_DOP2_LEAF_SCHEMA(
+        {ATTR_DEVICE_ID: "abc123", ATTR_UNIT: 2, ATTR_ATTRIBUTE: 1585}
+    )
+    assert result[ATTR_IDX1] == 0
+    assert result[ATTR_IDX2] == 0
+
+
+def test_schema_coerces_string_numbers() -> None:
+    result = DUMP_DOP2_LEAF_SCHEMA(
+        {ATTR_DEVICE_ID: "abc123", ATTR_UNIT: "2", ATTR_ATTRIBUTE: "1585"}
+    )
+    assert result[ATTR_UNIT] == 2
+    assert result[ATTR_ATTRIBUTE] == 1585
+
+
+def test_schema_rejects_out_of_range_unit() -> None:
+    with pytest.raises(vol.Invalid):
+        DUMP_DOP2_LEAF_SCHEMA(
+            {ATTR_DEVICE_ID: "abc123", ATTR_UNIT: 999999, ATTR_ATTRIBUTE: 1585}
+        )


### PR DESCRIPTION
Addresses #15. Also unblocks #12 and #8/#10.

#15 asks for dishwasher consumables (salt, rinse aid, PowerDisk). The reporter has the appliance, knows the true values from the Miele cloud, and offered to walk the leaf space — but wrote:

> The integration currently registers no services, so there is no way to probe from inside Home Assistant.

That is the actual blocker, and it is the same one behind the hood controls in #12 and the laundry gaps in #8/#10: the data lives on appliances nobody working on this repo owns, and the people who do own them have no way to look. This adds the missing tool.

## The service

`miele_lan.dump_dop2_leaf` — pick a device, give a `unit` and `attribute` (plus optional `idx1`/`idx2`), get the raw leaf body back as hex.

It returns a **service response**, so from Developer Tools → Actions the result appears as YAML that can be pasted straight into an issue:

```yaml
unit: 2
attribute: 1585
idx1: 0
idx2: 0
status: 404
length: 9
hex: "6e6f7420666f756e64"
```

Deliberate design points:

- **Read-only.** A GET, and nothing else. There is no write path here and no way to reach one.
- **A non-200 is an answer, not an error.** 403/404/500 are exactly what tells a user whether their firmware exposes a leaf, so those return a response carrying the status. Only a genuine connection failure raises.
- **No key material, ever.** The response carries leaf bytes, the status and the length — never the GroupID/GroupKey, never the appliance address.
- **No decoding.** Raw hex is the deliverable; working out what the bytes mean comes after real samples arrive, and needs the ground truth only the reporter has.

## Registration lifecycle

Registered once, guarded by `has_service`, so several households or a reload of one entry cannot double-register or drop the service out from under another entry. Removed only when the last loaded entry unloads — `async_loaded_entries` excludes the entry currently unloading, since HA sets its state before calling `async_unload_entry`. This mirrors what `rainmachine` does in core.

## Verification

- `pytest tests/ -q` → **86 passed** (77 existing + 9 new covering path building, hex normalisation, status coverage, and schema coercion/defaults/range rejection).
- The three translation files carry an identical 19-key `services` block, and `services.yaml`'s five field names match `strings.json` exactly — checked programmatically, because the previous PR was failing hassfest on precisely this class of mismatch.
- Smoke-tested against a stub client returning 404: returns the response dict rather than raising.
- Rebased onto current main; #26's options block is intact.

## Known limitation

If an entry's setup raises `ConfigEntryNotReady`, HA never calls `async_unload_entry`, so the service can stay registered with no coordinator behind it until a restart. Calling it in that state fails cleanly with an explanatory error rather than crashing. The same limitation exists in core's `rainmachine`.