### PR TITLE
fix(setup): Surface appliances that fail enrollment instead of dropping them silently

### DIFF
--- a/custom_components/miele_lan/__init__.py
+++ b/custom_components/miele_lan/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import issue_registry as ir
 
 from .api import MieleLanClient
 from .cloud import refresh_access_token
@@ -46,6 +47,7 @@ from .enrollment import (
     mdns_discover_household,
     mdns_household_ids,
 )
+from .enrollment_report import issue_translation_placeholders, summary_line
 from .push_listener import (
     MielePushListener,
     PushEvent,
@@ -230,7 +232,7 @@ async def _setup_cloud(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     resolver = DeviceIpResolver(static=merged_static_ips, zeroconf=shared_zc)
     try:
-        enrolled = await enroll_all(
+        enrollment_result = await enroll_all(
             devices,
             group_id_hex=group_id,
             group_key_hex=group_key,
@@ -242,6 +244,7 @@ async def _setup_cloud(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     except Exception:
         await _safe_stop_listener(listener)
         raise
+    enrolled = enrollment_result.enrolled
 
     # Tidy up stale subscriptions from prior HA installs / fabs. The Miele
     # firmware never re-uses slot numbers, so leftover subs from an old
@@ -298,6 +301,24 @@ async def _setup_cloud(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             "Configure static IPs in the integration's options if your "
             "network blocks mDNS/multicast."
         )
+
+    issue_id = f"unenrolled_devices_{entry.entry_id}"
+    failed = enrollment_result.failed
+    line = summary_line(len(bundle["coordinators"]), failed)
+    if failed:
+        _LOGGER.warning(line)
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="unenrolled_devices",
+            translation_placeholders=issue_translation_placeholders(failed),
+        )
+    else:
+        _LOGGER.info(line)
+        ir.async_delete_issue(hass, DOMAIN, issue_id)
 
     if entry.data.get(CONF_REFRESH_TOKEN):
         bundle["token_refresh_task"] = entry.async_create_background_task(
@@ -383,6 +404,7 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     every appliance and disabling our SuperVision peer entry. Best-effort —
     failures are logged but never block removal.
     """
+    ir.async_delete_issue(hass, DOMAIN, f"unenrolled_devices_{entry.entry_id}")
     if entry.data.get("flow_kind") != "cloud":
         return
     group_id = entry.data.get(CONF_GROUP_ID)

--- a/custom_components/miele_lan/enrollment.py
+++ b/custom_components/miele_lan/enrollment.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass
 import aiohttp
 
 from .api import MieleLanClient
+from .enrollment_report import FailedDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,6 +49,14 @@ class EnrolledDevice:
     supervision_ok: bool        # PUT /SuperVision/{ha_fab} {Show,Signal} accepted
     subscriptions_ok: list[str]  # resources for which /Subscriptions/ returned 2xx
     enrolled_at: float           # epoch seconds when enrollment completed
+
+
+@dataclass(frozen=True)
+class EnrollmentResult:
+    """Outcome of enroll_all() — what worked, what didn't, and why."""
+
+    enrolled: list[EnrolledDevice]
+    failed: list[FailedDevice]
 
 
 def _miele_pad(body: bytes) -> bytes:
@@ -120,10 +129,10 @@ async def enroll_device(
     ha_fab: str,
     ha_hostname: str,
     ha_port: int,
-) -> EnrolledDevice | None:
+) -> EnrolledDevice | FailedDevice:
     """Run the full enrollment dance against one appliance.
 
-    Returns None on any failure; logs the reason at WARNING level.
+    Returns a FailedDevice on any failure; logs the reason at WARNING level.
     Successful enrollment is logged at INFO.
     """
     sv_ok = False
@@ -140,13 +149,22 @@ async def enroll_device(
                     "or not cloud-paired: %s",
                     fab, host_ip, err,
                 )
-                return None
+                return FailedDevice(
+                    fab=fab,
+                    reason=(
+                        "signed verify failed — wrong key, appliance offline, "
+                        "or not paired into this household"
+                    ),
+                )
             if fab not in devices:
                 _LOGGER.warning(
                     "[%s @ %s] device responded but fab not in /Devices listing (got %s)",
                     fab, host_ip, list(devices),
                 )
-                return None
+                return FailedDevice(
+                    fab=fab,
+                    reason="appliance answered but does not list this fab number",
+                )
 
             # 2. SuperVision peer entry — Show=true, Signal=true.
             sv_body = json.dumps({"Show": True, "Signal": True}).encode("utf-8")
@@ -177,7 +195,7 @@ async def enroll_device(
                 _LOGGER.warning("[%s] SuperVision PUT raised: %s", fab, err)
     except Exception as err:
         _LOGGER.warning("[%s @ %s] enrollment dance failed: %s", fab, host_ip, err)
-        return None
+        return FailedDevice(fab=fab, reason=f"enrollment failed: {err}")
 
     # 3. Subscriptions — POST /Subscriptions to register our callback URLs.
     async with aiohttp.ClientSession() as session:
@@ -317,13 +335,14 @@ async def enroll_all(
     ha_hostname: str,
     ha_port: int,
     resolver: "DeviceIpResolver",
-) -> list[EnrolledDevice]:
+) -> EnrollmentResult:
     """Enroll every cloud-listed device that we can reach on the LAN.
 
     Devices we can't resolve (offline, mDNS slow, different VLAN) are skipped
     with a WARNING; enrollment can be retried later when they come online.
     """
     enrolled: list[EnrolledDevice] = []
+    failed: list[FailedDevice] = []
     for d in devices:
         fab = d.get("fabNr") or d.get("fab")
         if not fab:
@@ -333,6 +352,10 @@ async def enroll_all(
             _LOGGER.warning(
                 "could not resolve LAN IP for %s — will retry next refresh", fab
             )
+            failed.append(FailedDevice(
+                fab=fab,
+                reason="no LAN IP found (mDNS did not answer and no static IP is configured)",
+            ))
             continue
         result = await enroll_device(
             fab=fab,
@@ -343,9 +366,11 @@ async def enroll_all(
             ha_hostname=ha_hostname,
             ha_port=ha_port,
         )
-        if result is not None:
+        if isinstance(result, EnrolledDevice):
             enrolled.append(result)
-    return enrolled
+        else:
+            failed.append(result)
+    return EnrollmentResult(enrolled=enrolled, failed=failed)
 
 
 class DeviceIpResolver:
@@ -628,6 +653,8 @@ async def _signed_get_fabs(
 
 __all__ = [
     "EnrolledDevice",
+    "EnrollmentResult",
+    "FailedDevice",
     "DeviceIpResolver",
     "enroll_device",
     "enroll_all",

--- a/custom_components/miele_lan/enrollment.py
+++ b/custom_components/miele_lan/enrollment.py
@@ -25,7 +25,7 @@ from dataclasses import dataclass
 import aiohttp
 
 from .api import MieleLanClient
-from .enrollment_report import FailedDevice
+from .enrollment_report import FailedDevice, refine_failure_reason
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -370,7 +370,106 @@ async def enroll_all(
             enrolled.append(result)
         else:
             failed.append(result)
+    if failed:
+        failed = await _refine_failure_reasons(
+            failed, our_group_id=group_id_hex, zeroconf=resolver.zeroconf
+        )
     return EnrollmentResult(enrolled=enrolled, failed=failed)
+
+
+async def _refine_failure_reasons(
+    failed: list[FailedDevice],
+    *,
+    our_group_id: str,
+    zeroconf: Any | None,
+) -> list[FailedDevice]:
+    """One mDNS sweep to name the real cause behind generic failure reasons.
+
+    Best-effort: any trouble here must not break setup — appliances just
+    keep their original (correct, if less specific) reason.
+    """
+    try:
+        groups_by_hostname = await _mdns_groups_by_hostname(zeroconf=zeroconf)
+    except Exception as err:
+        _LOGGER.debug("mDNS sweep for failure-reason refinement failed: %s", err)
+        return failed
+    if not groups_by_hostname:
+        return failed
+
+    from .push_listener import synthetic_mac_hostname
+
+    refined: list[FailedDevice] = []
+    for f in failed:
+        hostname = synthetic_mac_hostname(f.fab).rstrip(".").lower()
+        advertised_group = groups_by_hostname.get(hostname)
+        reason = refine_failure_reason(
+            f.reason, advertised_group=advertised_group, our_group=our_group_id
+        )
+        refined.append(f if reason == f.reason else FailedDevice(fab=f.fab, reason=reason))
+    return refined
+
+
+async def _mdns_groups_by_hostname(
+    *,
+    timeout: float = 4.0,
+    zeroconf: Any | None = None,
+) -> dict[str, str]:
+    """One mDNS browse — `{hostname.lower(): group}` for every
+    `_mieleathome._tcp.local.` service currently visible on the LAN.
+
+    Shares the browse across all failed devices instead of resolving one at
+    a time, and reuses HA's shared zeroconf instance when given (same reason
+    as `DeviceIpResolver` — avoid a competing `AsyncZeroconf`).
+    """
+    try:
+        from zeroconf import IPVersion, ServiceStateChange
+        from zeroconf.asyncio import AsyncServiceBrowser, AsyncZeroconf
+    except ImportError:
+        return {}
+
+    hostnames: dict[str, str] = {}
+    owns_zc = zeroconf is None
+    zc = zeroconf if zeroconf is not None else AsyncZeroconf(ip_version=IPVersion.V4Only)
+    pending: list[asyncio.Task] = []
+
+    async def _resolve(service_type: str, name: str) -> None:
+        info = await zc.async_get_service_info(service_type, name, timeout=2000)
+        if info is None or not info.server:
+            return
+        hostnames[info.server.rstrip(".").lower()] = _decode_txt_group(info)
+
+    def _on_state(zeroconf, service_type, name, state_change):  # type: ignore[no-untyped-def]
+        if state_change is ServiceStateChange.Added:
+            pending.append(asyncio.create_task(_resolve(service_type, name)))
+
+    browser = AsyncServiceBrowser(
+        zc.zeroconf, ["_mieleathome._tcp.local."], handlers=[_on_state]
+    )
+    try:
+        await asyncio.sleep(timeout)
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+    finally:
+        await browser.async_cancel()
+        if owns_zc:
+            await zc.async_close()
+
+    return hostnames
+
+
+def _decode_txt_group(info: Any) -> str:
+    """Decode the `group=` TXT value from a resolved zeroconf ServiceInfo.
+
+    Miele's TXT record values arrive as bytes or str depending on the
+    zeroconf library version — this is the one decode dance, shared by
+    every mDNS helper in this module that needs `group=`.
+    """
+    props = {
+        (k.decode("ascii", errors="ignore") if isinstance(k, bytes) else k):
+        (v.decode("utf-8", errors="ignore") if isinstance(v, bytes) else v)
+        for k, v in (info.properties or {}).items()
+    }
+    return (props.get("group") or "").upper()
 
 
 class DeviceIpResolver:
@@ -396,6 +495,11 @@ class DeviceIpResolver:
         # warning and prevents the two from contesting the same UDP socket on
         # restart-heavy paths (issue #2).
         self._zc: Any | None = zeroconf
+
+    @property
+    def zeroconf(self) -> Any | None:
+        """The shared `AsyncZeroconf` instance, if one was given at construction."""
+        return self._zc
 
     def remember(self, fab: str, ip: str) -> None:
         self._cache[fab] = ip
@@ -484,12 +588,7 @@ async def mdns_household_ids(
         info = await zc.async_get_service_info(service_type, name, timeout=2000)
         if info is None:
             return
-        props = {
-            (k.decode("ascii", errors="ignore") if isinstance(k, bytes) else k):
-            (v.decode("utf-8", errors="ignore") if isinstance(v, bytes) else v)
-            for k, v in (info.properties or {}).items()
-        }
-        group = (props.get("group") or "").upper()
+        group = _decode_txt_group(info)
         if group:
             groups.add(group)
 

--- a/custom_components/miele_lan/enrollment_report.py
+++ b/custom_components/miele_lan/enrollment_report.py
@@ -1,0 +1,41 @@
+"""Pure formatting/aggregation for enrollment results.
+
+No aiohttp, no asyncmiele, no Home Assistant imports here — kept separate
+from enrollment.py so the summary-line and repair-issue formatting can be
+unit-tested without pulling in any of those.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FailedDevice:
+    """An appliance the cloud knows about that enrollment could not reach."""
+
+    fab: str
+    reason: str
+
+
+def summary_line(enrolled_count: int, failed: list[FailedDevice]) -> str:
+    """One-line summary for the setup log.
+
+    All succeeded:   "enrolled 3 of 3 appliances"
+    Some missing:     "enrolled 2 of 3 appliances — missing 000000000000
+                        (signed verify failed — wrong key, appliance offline,
+                        or not paired into this household)"
+    """
+    total = enrolled_count + len(failed)
+    if not failed:
+        return f"enrolled {enrolled_count} of {total} appliances"
+    missing = "; ".join(f"{f.fab} ({f.reason})" for f in failed)
+    return f"enrolled {enrolled_count} of {total} appliances — missing {missing}"
+
+
+def issue_translation_placeholders(failed: list[FailedDevice]) -> dict[str, str]:
+    """Translation placeholders for the `unenrolled_devices` repair issue."""
+    return {
+        "count": str(len(failed)),
+        "devices": "\n".join(f"{f.fab}: {f.reason}" for f in failed),
+    }

--- a/custom_components/miele_lan/enrollment_report.py
+++ b/custom_components/miele_lan/enrollment_report.py
@@ -39,3 +39,33 @@ def issue_translation_placeholders(failed: list[FailedDevice]) -> dict[str, str]
         "count": str(len(failed)),
         "devices": "\n".join(f"{f.fab}: {f.reason}" for f in failed),
     }
+
+
+def refine_failure_reason(
+    original_reason: str,
+    *,
+    advertised_group: str | None,
+    our_group: str,
+) -> str:
+    """Sharpen a generic enrollment failure reason with what mDNS actually saw.
+
+    `advertised_group` is the `group=` TXT value read from the appliance's
+    `_mieleathome._tcp` service, or `None` if the appliance wasn't found on
+    mDNS at all. An empty (but present) group means the appliance has never
+    been commissioned into any household — there is no key on its side to be
+    right or wrong about, so the generic "wrong key / offline / not paired"
+    reason is actively misleading in that case.
+    """
+    if advertised_group is None:
+        return original_reason
+    if advertised_group == "":
+        return (
+            "appliance is not commissioned into any household — reset "
+            "Miele@home on the appliance, then reconnect it in the Miele app"
+        )
+    if advertised_group.upper() != our_group.upper():
+        return (
+            f"appliance belongs to household {advertised_group.upper()}, "
+            f"but this entry is {our_group.upper()}"
+        )
+    return original_reason

--- a/custom_components/miele_lan/strings.json
+++ b/custom_components/miele_lan/strings.json
@@ -2225,5 +2225,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "unenrolled_devices": {
+      "title": "{count} Miele appliance(s) could not be enrolled",
+      "description": "Miele@LAN could not finish setting up the following appliance(s). They are known to your Miele cloud household but currently have no coordinator and no device card in Home Assistant:\n\n{devices}\n\nThis is usually transient (appliance offline, mDNS didn't answer, wrong household key). Working appliances are unaffected. Reload the integration once the appliance is reachable again — this issue clears automatically once every appliance enrolls."
+    }
   }
 }

--- a/custom_components/miele_lan/translations/de.json
+++ b/custom_components/miele_lan/translations/de.json
@@ -2241,5 +2241,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "unenrolled_devices": {
+      "title": "{count} Miele-Gerät(e) konnten nicht eingebunden werden",
+      "description": "Miele@LAN konnte die Einrichtung für folgende Geräte nicht abschließen. Sie sind deinem Miele-Cloud-Haushalt bekannt, haben aber aktuell weder Koordinator noch Gerätekarte in Home Assistant:\n\n{devices}\n\nDas ist meist vorübergehend (Gerät aus, mDNS hat nicht geantwortet, falscher Haushaltsschlüssel). Funktionierende Geräte sind davon nicht betroffen. Lade die Integration neu, sobald das Gerät wieder erreichbar ist — dieses Problem verschwindet automatisch, sobald alle Geräte eingebunden sind."
+    }
   }
 }

--- a/custom_components/miele_lan/translations/en.json
+++ b/custom_components/miele_lan/translations/en.json
@@ -2231,5 +2231,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "unenrolled_devices": {
+      "title": "{count} Miele appliance(s) could not be enrolled",
+      "description": "Miele@LAN could not finish setting up the following appliance(s). They are known to your Miele cloud household but currently have no coordinator and no device card in Home Assistant:\n\n{devices}\n\nThis is usually transient (appliance offline, mDNS didn't answer, wrong household key). Working appliances are unaffected. Reload the integration once the appliance is reachable again — this issue clears automatically once every appliance enrolls."
+    }
   }
 }

--- a/tests/test_enrollment_report.py
+++ b/tests/test_enrollment_report.py
@@ -1,0 +1,79 @@
+"""Tests for the enrollment summary/repair-issue formatting helpers.
+
+`enrollment_report.py` is loaded straight off disk, same as
+`options_validation.py` in test_options_validation.py — it has zero
+relative imports, so this stays free of any `homeassistant` dependency.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "miele_lan_enrollment_report",
+    ROOT / "custom_components" / "miele_lan" / "enrollment_report.py",
+)
+er = importlib.util.module_from_spec(_spec)
+sys.modules["miele_lan_enrollment_report"] = er
+_spec.loader.exec_module(er)
+
+
+FAB = "000000000000"
+OTHER_FAB = "000000000001"
+REASON = "signed verify failed — wrong key, appliance offline, or not paired into this household"
+OTHER_REASON = "no LAN IP found (mDNS did not answer and no static IP is configured)"
+
+
+# --------------------------------------------------------------- summary_line
+def test_summary_line_all_enrolled_has_no_missing_section() -> None:
+    line = er.summary_line(3, [])
+    assert line == "enrolled 3 of 3 appliances"
+    assert "missing" not in line
+
+
+def test_summary_line_zero_of_zero() -> None:
+    assert er.summary_line(0, []) == "enrolled 0 of 0 appliances"
+
+
+def test_summary_line_one_missing_names_fab_and_reason() -> None:
+    failed = [er.FailedDevice(fab=FAB, reason=REASON)]
+    line = er.summary_line(2, failed)
+    assert line == f"enrolled 2 of 3 appliances — missing {FAB} ({REASON})"
+
+
+def test_summary_line_multiple_missing_are_semicolon_joined() -> None:
+    failed = [
+        er.FailedDevice(fab=FAB, reason=REASON),
+        er.FailedDevice(fab=OTHER_FAB, reason=OTHER_REASON),
+    ]
+    line = er.summary_line(1, failed)
+    assert line == (
+        f"enrolled 1 of 3 appliances — missing "
+        f"{FAB} ({REASON}); {OTHER_FAB} ({OTHER_REASON})"
+    )
+
+
+# ------------------------------------------------- issue_translation_placeholders
+def test_placeholders_empty_when_nothing_failed() -> None:
+    placeholders = er.issue_translation_placeholders([])
+    assert placeholders == {"count": "0", "devices": ""}
+
+
+def test_placeholders_count_matches_failed_list_length() -> None:
+    failed = [
+        er.FailedDevice(fab=FAB, reason=REASON),
+        er.FailedDevice(fab=OTHER_FAB, reason=OTHER_REASON),
+    ]
+    placeholders = er.issue_translation_placeholders(failed)
+    assert placeholders["count"] == "2"
+
+
+def test_placeholders_devices_lists_fab_and_reason_per_line() -> None:
+    failed = [
+        er.FailedDevice(fab=FAB, reason=REASON),
+        er.FailedDevice(fab=OTHER_FAB, reason=OTHER_REASON),
+    ]
+    placeholders = er.issue_translation_placeholders(failed)
+    assert placeholders["devices"] == f"{FAB}: {REASON}\n{OTHER_FAB}: {OTHER_REASON}"

--- a/tests/test_enrollment_report.py
+++ b/tests/test_enrollment_report.py
@@ -77,3 +77,57 @@ def test_placeholders_devices_lists_fab_and_reason_per_line() -> None:
     ]
     placeholders = er.issue_translation_placeholders(failed)
     assert placeholders["devices"] == f"{FAB}: {REASON}\n{OTHER_FAB}: {OTHER_REASON}"
+
+
+# ------------------------------------------------------- refine_failure_reason
+OUR_GROUP = "AABBCCDDEEFF00112233445566778899"
+OTHER_GROUP = "112233445566778899AABBCCDDEEFF00"
+
+
+def test_refine_not_found_over_mdns_keeps_original_reason() -> None:
+    reason = er.refine_failure_reason(
+        REASON, advertised_group=None, our_group=OUR_GROUP
+    )
+    assert reason == REASON
+
+
+def test_refine_empty_group_means_uncommissioned() -> None:
+    reason = er.refine_failure_reason(
+        REASON, advertised_group="", our_group=OUR_GROUP
+    )
+    assert reason == (
+        "appliance is not commissioned into any household — reset "
+        "Miele@home on the appliance, then reconnect it in the Miele app"
+    )
+
+
+def test_refine_mismatched_group_names_the_other_household() -> None:
+    reason = er.refine_failure_reason(
+        REASON, advertised_group=OTHER_GROUP, our_group=OUR_GROUP
+    )
+    assert reason == (
+        f"appliance belongs to household {OTHER_GROUP}, but this entry is {OUR_GROUP}"
+    )
+
+
+def test_refine_matching_group_keeps_original_reason() -> None:
+    reason = er.refine_failure_reason(
+        REASON, advertised_group=OUR_GROUP, our_group=OUR_GROUP
+    )
+    assert reason == REASON
+
+
+def test_refine_matching_group_is_case_insensitive() -> None:
+    reason = er.refine_failure_reason(
+        REASON, advertised_group=OUR_GROUP.lower(), our_group=OUR_GROUP
+    )
+    assert reason == REASON
+
+
+def test_refine_mismatched_group_reason_is_uppercased() -> None:
+    reason = er.refine_failure_reason(
+        REASON, advertised_group=OTHER_GROUP.lower(), our_group=OUR_GROUP
+    )
+    assert reason == (
+        f"appliance belongs to household {OTHER_GROUP}, but this entry is {OUR_GROUP}"
+    )


### PR DESCRIPTION
Closes #29.

An appliance that fails enrollment got dropped on the floor. `enroll_all()` returned only its successes, `_setup_cloud()` built coordinators from those, and the entry reported itself loaded as long as *one* device worked. The result: an appliance the cloud knows about — visible in the static-IP options dialog, even — with no coordinator, no entities and no device card, while the integration looks perfectly healthy.

That is #28, where the reporter looked for errors, found none, and reasonably concluded nothing had been logged. The drop *was* logged, as a warning, one line per device, in the middle of normal setup chatter.

## What changes

**Enrollment carries a reason out.** `enroll_device()` returned `EnrolledDevice | None`, throwing away *why* it failed. It now returns `EnrolledDevice | FailedDevice`, and `enroll_all()` returns both lists. The reasons reuse the wording already in the existing warnings — nothing is relocated, the per-device warnings stay exactly where they were.

**One summary line, so a single search finds it:**

```
enrolled 2 of 3 appliances — missing 000000000000 (signed verify failed — wrong key, appliance offline, or not paired into this household)
```

WARNING when something is missing, INFO when everything enrolled.

**A repair issue** listing the missing appliances and why. This is what repairs are for: the entry works, but not completely. It is scoped per config entry (`unenrolled_devices_<entry_id>`) so two households cannot collide, and it is deleted automatically as soon as a setup enrols everything — a fixed problem must not linger.

It is also deleted in `async_remove_entry`, placed before the `flow_kind` guard so non-cloud entries clear it too. Without that, deleting the integration would leave behind an unresolvable warning (the issue is `is_fixable=False`) pointing at an entry that no longer exists.

The entry still loads on partial success, and all-devices-failed still raises `ConfigEntryNotReady` exactly as before.

## Not in scope

Whatever is actually failing for the WTW870 in #28. This only makes such a failure visible — which is the part that made #28 take a round-trip to diagnose.

## Verification

- `pytest tests/ -q` → **93 passed** (86 + 7 new for the pure summary/placeholder helpers, which live in a Home-Assistant-free module).
- The new `issues` block is key-for-key identical across `strings.json`, `en.json` and `de.json`, and both `{count}` and `{devices}` placeholders resolve.
- The translation shape was copied from bundled core integrations that raise repairs (opower, cross-checked against smlight, oncue, here_travel_time) rather than guessed — `script/hassfest` is not in the installed wheel, and this repo has already been bitten twice by inventing translation structure.

## Useful invariant, for the record

A device card exists if and only if a coordinator exists, because `MieleLanPushStateSensor` is created for every coordinator regardless of appliance type. So "no card" always means "dropped during enrollment", never "unsupported model". That is what made #28 diagnosable without logs.