### PR TITLE
feat(hood): Add local ventilation, run-on time and filter sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,15 @@ Local Home Assistant integration for Miele@home appliances — ovens, hobs, dish
 | **Washer / dryer / washer-dryer** | WWG/TWC/WWV/WTV series | status, program, phase, drying step, remaining/elapsed/start time, door, signals | start / stop / pause, wake |
 | **Fridge / freezer / fridge-freezer** | KF 7772 B, K 7000, KFN, KFNS, … | per-zone current + target temp, per-zone door, SuperCool, SuperFreeze, failure | — *(see Limitations)* |
 | **Wine cabinet** | KWT 6000, KWNS, KWTUS, wine + freezer | per-zone temp, per-zone door, light state | — *(see Limitations)* |
-| **Hood / range vent** | DA series | fan step, light state | light |
+| **Hood / range vent** | DA series, EK039W | fan step, light state, grease & charcoal filter saturation† | fan (off / 1-3 / boost)†, fan run-on time†, light |
 | **Coffee system** | CVA series | status, program, phase | start, stop, pause, wake, power |
 | **Dish warmer** | ESW series | status | start, stop, wake, power |
 
 Diagnostic entities (raw enums, WLAN info, push state, firmware version) are created but disabled by default — enable them per device under **Configure entities**.
 
 \* Oven setpoint writes work where firmware honours `MobileStart` (RE'd on H7560BP). Some appliances may need MobileStart enabled on the panel.
+
+† Hood ventilation, run-on time and filter saturation use the legacy Dop1 protocol, which the official Miele app itself picks for hoods reporting `ProtocolVersion 2` — the DOP2 path every other control here uses answers HTTP 404 on this hardware. Hoods reporting 3/4 keep the read-only fan-step sensor and the light.
 
 ## Installation
 

--- a/custom_components/miele_lan/__init__.py
+++ b/custom_components/miele_lan/__init__.py
@@ -59,7 +59,9 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.FAN,
     Platform.LIGHT,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
 ]

--- a/custom_components/miele_lan/api.py
+++ b/custom_components/miele_lan/api.py
@@ -20,6 +20,7 @@ import asyncio
 import binascii
 import json
 import logging
+import struct
 from typing import Any
 
 import aiohttp
@@ -42,10 +43,21 @@ from asyncmiele.utils.http_consts import (
 
 from .const import (
     DEVICE_ACTION_WAKE,
+    DOP1_LIGHTINGMODE_COOKING,
+    DOP1_LIGHTINGMODE_OFF,
+    DOP1_LUEFTERSTEUERUNG_OBJECT_ID,
+    DOP1_NACHLAUFZEIT_OBJECT_ID,
+    DOP1_REQUEST_TYPE_READ,
+    DOP1_REQUEST_TYPE_WRITE,
+    DOP1_SETTING_PF_OBJECT_ID,
+    DOP1_SWITCHLIGHT_LICHTQUELLE_MAIN,
+    DOP1_SWITCHLIGHT_OBJECT_ID,
+    DOP1_SWITCHLIGHT_STRUKTUR_VERSION,
     OPCODE_LIGHT_OFF,
     OPCODE_LIGHT_ON,
     OPCODE_SWITCH_OFF,
     OPCODE_SWITCH_ON,
+    RUN_ON_TIME_MINUTES,
     USER_REQUEST_LEAF,
     USER_REQUEST_UNIT,
 )
@@ -88,6 +100,102 @@ def build_user_request_payload(opcode: int) -> bytes:
     if not 0 <= opcode <= 0xFF:
         raise ValueError(f"opcode out of range: {opcode}")
     return _OVEN_REQ_PREFIX + bytes([opcode]) + _OVEN_REQ_SUFFIX
+
+
+# --- Dop1 request builders --------------------------------------------------
+# A Dop1 request is the hex string "{ObjectId}{RequestType}00{struct}", posted
+# as {"Request": ...} to /Devices/{fab}/DOP/. Kept pure (no I/O) so the wire
+# format can be tested without hardware — see tests/test_dop1_hood_payloads.py.
+# Layouts are documented per-object in const.py.
+
+
+def _dop1_request(object_id: str, request_type: str, section: bytes) -> str:
+    return f"{object_id}{request_type}00{section.hex().upper()}"
+
+
+def build_dop1_fan_level_request(level: int) -> str:
+    """ServiceDataExt_Lueftersteuerung write — set the hood fan to `level`."""
+    if not 0 <= level <= 5:
+        raise ValueError(f"fan level out of range: {level}")
+    section = bytes([0, 0xFF, level, 0])
+    return _dop1_request(
+        DOP1_LUEFTERSTEUERUNG_OBJECT_ID, DOP1_REQUEST_TYPE_WRITE, section
+    )
+
+
+def build_dop1_run_on_time_request(minutes: int) -> str:
+    """ServiceDataExt_Nachlaufzeit write — set the hood fan run-on time."""
+    if minutes not in RUN_ON_TIME_MINUTES:
+        raise ValueError(
+            f"run-on time must be one of {RUN_ON_TIME_MINUTES}: {minutes}"
+        )
+    return _dop1_request(
+        DOP1_NACHLAUFZEIT_OBJECT_ID, DOP1_REQUEST_TYPE_WRITE, bytes([0, minutes])
+    )
+
+
+def build_dop1_main_light_request(on: bool) -> str:
+    """SwitchLight_W write — switch the hood's main light on or off."""
+    section = bytearray(13)
+    section[0] = DOP1_SWITCHLIGHT_STRUKTUR_VERSION
+    section[1] = DOP1_SWITCHLIGHT_LICHTQUELLE_MAIN
+    section[2] = DOP1_LIGHTINGMODE_COOKING if on else DOP1_LIGHTINGMODE_OFF
+    # Rot/Gruen/Blau_Dimmwert (offsets 3, 5, 7) stay 0.
+    struct.pack_into(">H", section, 9, 0xFFFF if on else 0)  # WW_Dimmwert
+    struct.pack_into(">H", section, 11, 0)  # KW_Dimmwert
+    return _dop1_request(
+        DOP1_SWITCHLIGHT_OBJECT_ID, DOP1_REQUEST_TYPE_WRITE, bytes(section)
+    )
+
+
+def build_dop1_setting_pf_write_request(pf_id: int, value: int) -> str:
+    """Setting_PF_Schreiben_BE — write a Programmierfunktion value."""
+    if not 0 <= pf_id <= 0xFFFF:
+        raise ValueError(f"PF id out of range: {pf_id}")
+    if not 0 <= value <= 0xFFFFFFFF:
+        raise ValueError(f"PF value out of range: {value}")
+    section = bytearray(7)
+    struct.pack_into(">H", section, 1, pf_id)
+    struct.pack_into(">I", section, 3, value)
+    return _dop1_request(
+        DOP1_SETTING_PF_OBJECT_ID, DOP1_REQUEST_TYPE_WRITE, bytes(section)
+    )
+
+
+def build_dop1_setting_pf_read_request(pf_id: int) -> str:
+    """Setting_PF_Lesen_BE — ask for a Programmierfunktion's current value."""
+    if not 0 <= pf_id <= 0xFFFF:
+        raise ValueError(f"PF id out of range: {pf_id}")
+    section = bytearray(3)
+    struct.pack_into(">H", section, 1, pf_id)
+    return _dop1_request(
+        DOP1_SETTING_PF_OBJECT_ID, DOP1_REQUEST_TYPE_READ, bytes(section)
+    )
+
+
+def parse_dop1_setting_pf_value(response_hex: str, pf_id: int) -> int | None:
+    """Pull the `Wert` (U32) out of a Setting_PF read response.
+
+    The response carries a framing prefix (object id + message type) whose
+    exact width isn't pinned down, so instead of assuming an offset we locate
+    the echoed PF_ID and read the U32 that follows it. To avoid matching the
+    same two bytes somewhere inside the framing, a candidate only counts if
+    it sits on a byte boundary and the full 12 trailing bytes of the read
+    section (Wert + Min + Max) still fit.
+
+    Returns None when the value isn't locatable — callers treat that as
+    "this appliance doesn't expose this setting".
+    """
+    digits = response_hex.strip().upper()
+    if len(digits) % 2:  # not whole bytes — not something we can index into
+        return None
+    needle = f"{pf_id & 0xFFFF:04X}"
+    start = 0
+    while (idx := digits.find(needle, start)) != -1:
+        if idx % 2 == 0 and idx + 4 + 24 <= len(digits):
+            return int(digits[idx + 4 : idx + 12], 16)
+        start = idx + 2
+    return None
 
 
 async def _patched_request_bytes(
@@ -354,6 +462,90 @@ class MieleLanClient:
 
     async def switch_off(self) -> None:
         await self.write_user_request(OPCODE_SWITCH_OFF)
+
+    # --- legacy Dop1 writes (hood ventilation / light / settings) -----------
+
+    async def _dop1_post(self, request: str, *, what: str) -> bytes:
+        """POST a signed Dop1 request to /DOP/ and return the decrypted body.
+
+        HTTP 400 is the firmware's way of rejecting a no-op (re-asserting the
+        value the appliance already holds), the same convention `_put_state`
+        already tolerates for /State writes. An automation re-sending the
+        current fan level shouldn't surface as an error, so treat it as
+        success with an empty body.
+        """
+        try:
+            _, raw = await self._client._request_bytes(
+                "POST",
+                f"/Devices/{self._route}/DOP/",
+                body={"Request": request},
+                allowed_status=(200, 204),
+            )
+            return raw or b""
+        except ResponseError as exc:
+            if exc.status_code == 400:
+                _LOGGER.debug("%s: Dop1 %r returned 400 (likely no-op)", what, request)
+                return b""
+            raise HomeAssistantError(
+                f"{what} failed (HTTP {exc.status_code})."
+            ) from exc
+
+    async def set_fan_level(self, level: int) -> None:
+        """Set the hood's ventilation level (0 = off, 1-3, 4 = boost).
+
+        Hood-only, and only on ProtocolVersion==2 appliances — the same gate
+        the official app applies (see const.py). Returns as soon as the
+        appliance acks: turning on takes a few seconds to show up in
+        /State.VentilationStep while the motor spins up, and the push channel
+        delivers that update when it lands.
+        """
+        await self._dop1_post(
+            build_dop1_fan_level_request(level), what="Fan level write"
+        )
+
+    async def set_fan_run_on_time(self, minutes: int) -> None:
+        """Set the hood fan's run-on time (Nachlaufzeit) in minutes."""
+        await self._dop1_post(
+            build_dop1_run_on_time_request(minutes), what="Fan run-on time write"
+        )
+
+    async def set_main_light_dop1(self, on: bool) -> None:
+        """Switch the hood's main light via Dop1 SwitchLight_W.
+
+        Same result as `light_on()`/`light_off()` but much faster to apply on
+        hood firmware; callers keep the /State path as a fallback.
+        """
+        await self._dop1_post(
+            build_dop1_main_light_request(on), what="Main-light write"
+        )
+
+    async def write_setting_pf(self, pf_id: int, value: int) -> None:
+        """Write a Programmierfunktion setting via the generic Dop1 1201 object."""
+        await self._dop1_post(
+            build_dop1_setting_pf_write_request(pf_id, value),
+            what=f"Setting {pf_id} write",
+        )
+
+    async def read_setting_pf(self, pf_id: int) -> int | None:
+        """Read a Programmierfunktion setting's current value.
+
+        Returns None when the appliance doesn't answer with a value for this
+        setting, which is how callers detect an unsupported one.
+        """
+        raw = await self._dop1_post(
+            build_dop1_setting_pf_read_request(pf_id), what=f"Setting {pf_id} read"
+        )
+        if not raw:
+            return None
+        # The device answers with JSON {"Response": "<hex>"}; fall back to
+        # treating the body itself as the section if that shape ever changes.
+        try:
+            parsed = json.loads(raw.decode("utf-8", errors="replace"))
+            response_hex = parsed.get("Response", "") if isinstance(parsed, dict) else ""
+        except json.JSONDecodeError:
+            response_hex = raw.hex()
+        _LOGGER.debug("setting %d read response: %s", pf_id, response_hex)
+        return parse_dop1_setting_pf_value(response_hex, pf_id)
 
     # Cooling-family target-temperature writes are not supported via the LAN
     # protocol — see custom_components/miele_lan/climate.py for the RE notes.

--- a/custom_components/miele_lan/const.py
+++ b/custom_components/miele_lan/const.py
@@ -73,6 +73,68 @@ OPCODE_PROGRAM_ABORT = 0x37
 OPCODE_PROGRAM_FINALIZE = 0x38
 
 # ---------------------------------------------------------------------------
+# Legacy "Dop1" objects (hood ventilation, hood light, hood settings)
+# ---------------------------------------------------------------------------
+# Dop1 is a separate, older write mechanism from DOP2/GLOBAL_USER_REQ: a signed
+# `POST /Devices/{fab}/DOP/` carrying {"Request": "<hex>"}, where the hex is
+# "{ObjectId}{RequestType}00" followed by the object's own packed struct.
+#
+# It is the mechanism the official Miele app itself picks for hoods: its action
+# providers try [Dop1, OpCode, Dop2, Default] in order and the Dop1 variant's
+# `IsApplianceSpecificallySupported` is `ProtocolVersion == 2`, so on a
+# ProtocolVersion==2 hood the app never reaches the DOP2 path. That matters
+# here because GLOBAL_USER_REQ (leaf 2/1583) answers HTTP 404 outright on
+# these hoods — see `MieleLanClient.write_user_request`. Everything below was
+# recovered from the app's own action classes and then confirmed against real
+# hardware; `coordinator.hood_dop1_supported` mirrors the app's gate.
+DOP1_REQUEST_TYPE_READ = "01"
+DOP1_REQUEST_TYPE_WRITE = "02"
+
+# "ServiceDataExt_Lueftersteuerung" (ventilation control), from the app's
+# SetFanPowerLevelBaseAction. 4-byte write section:
+#   [0] Struktur_Version  = 0
+#   [1] Luefterauswahl    = 0xFF (all/default fan)
+#   [2] Luefterstufe      = 0..5 (FanPowerLevel: Off, 1, 2, 3, Booster, Interval)
+#   [3] Luefterleistung   = 0
+# Confirmed live: turning ON takes ~4s before /State.VentilationStep reflects
+# it (motor spin-up); turning OFF is near-instant (<1s). No keep-alive needed.
+DOP1_LUEFTERSTEUERUNG_OBJECT_ID = "8E01"
+
+# "ServiceDataExt_Nachlaufzeit" — fan run-on time, from SetFanRunOnTimeBaseAction.
+# 2-byte write section: [0] Struktur_Version = 0, [1] Nachlaufzeit in minutes.
+# The app itself only offers the discrete RunOnTimeLevel values below.
+DOP1_NACHLAUFZEIT_OBJECT_ID = "8E06"
+RUN_ON_TIME_MINUTES: tuple[int, ...] = (0, 5, 15)
+
+# "SwitchLight_W" — the hood's main cavity light, from the app's
+# LightingDop1Actions / ToggleLightSourceAsync(MainLightsource, ...).
+# 13-byte write section, all U16s big-endian:
+#   [0]     Struktur_Version = 2 (VersionEnum.Version_2_BE)
+#   [1]     Lichtquelle      = 1 (TypeLightSource.Licht_Kochfeld_ — main light)
+#   [2]     Betriebszustand  = LightingMode: 4 (CookingMode) on, 0 (Off) off
+#   [3:9]   Rot/Gruen/Blau_Dimmwert = 0
+#   [9:11]  WW_Dimmwert      = 0xFFFF when on, 0 when off
+#   [11:13] KW_Dimmwert      = 0
+# Worth having alongside the plain `PUT /State {"Light":1|2}` path because it
+# applies far faster on this firmware — measured ~0.8s vs ~4.9s to turn on.
+DOP1_SWITCHLIGHT_OBJECT_ID = "1400"
+DOP1_SWITCHLIGHT_STRUKTUR_VERSION = 2
+DOP1_SWITCHLIGHT_LICHTQUELLE_MAIN = 1
+DOP1_LIGHTINGMODE_OFF = 0
+DOP1_LIGHTINGMODE_COOKING = 4
+
+# Generic "Programmierfunktion" settings object (Setting_PF_Lesen/Schreiben_BE).
+# One object id for both directions, distinguished by the request-type byte:
+#   write section: [0] Version = 0, [1:3] PF_ID (U16 BE), [3:7] Wert (U32 BE)
+#   read  request: [0] Version = 0, [1:3] PF_ID (U16 BE)
+#   read  section: [0] Version, [1:3] PF_ID, [3:7] Wert, [7:11] Min, [11:15] Max
+DOP1_SETTING_PF_OBJECT_ID = "1201"
+
+# Hood Programmierfunktion ids (ProgrammierfunktionEnum; DA_* = Dunstabzug).
+PF_DA_FETTFILTER_GRENZE_AKTUELL = 40010   # current grease-filter saturation grade
+PF_DA_KOHLEFILTER_GRENZE_AKTUELL = 40011  # current charcoal-filter saturation grade
+
+# ---------------------------------------------------------------------------
 # Appliance taxonomy
 # ---------------------------------------------------------------------------
 # Mirror of HA core `miele.const.MieleAppliance`, which itself mirrors the

--- a/custom_components/miele_lan/coordinator.py
+++ b/custom_components/miele_lan/coordinator.py
@@ -21,7 +21,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import MieleLanClient
-from .const import DOMAIN, LAUNDRY_FAMILY, OVEN_FAMILY, MieleAppliance
+from .const import (
+    DOMAIN,
+    LAUNDRY_FAMILY,
+    OVEN_FAMILY,
+    PF_DA_FETTFILTER_GRENZE_AKTUELL,
+    PF_DA_KOHLEFILTER_GRENZE_AKTUELL,
+    MieleAppliance,
+)
 from .dop2 import parse_global_device_context, parse_hours_of_operation
 from .enrollment import EnrolledDevice
 from .push_listener import PushEvent
@@ -36,6 +43,10 @@ WLAN_REFRESH_INTERVAL = 300  # seconds — RSSI/signal-percentage drift slowly;
                              # 5-minute cadence keeps values roughly current.
 DEVICE_CONTEXT_REFRESH_INTERVAL = 600  # seconds — TwinDos fill level and wash2dry
                                        # state evolve on a per-cycle timescale.
+HOOD_FILTER_REFRESH_INTERVAL = 3600  # seconds — grease/charcoal filter saturation
+                                     # creeps up over weeks, so hourly is ample.
+IDENT_MAX_ATTEMPTS = 5  # /Ident is fetched once; these are the retries allowed
+                        # when it comes back without the fields entities gate on.
 
 
 @dataclass
@@ -77,11 +88,14 @@ class MieleLanCoordinator(DataUpdateCoordinator[MieleLanData]):
         self.enrollment = enrollment
         self._data = MieleLanData()
         self._ident_loaded = False
+        self._ident_attempts = 0
         self._dop2_last_fetch: float = 0.0
         self._hours_unsupported = False
         self._wlan_last_fetch: float = 0.0
         self._device_context_last_fetch: float = 0.0
         self._device_context_unsupported: bool = False
+        self._hood_filters_last_fetch: float = 0.0
+        self._hood_filters_unsupported: bool = False
         self._last_push_at: float | None = None
         self._push_count = 0
 
@@ -106,6 +120,33 @@ class MieleLanCoordinator(DataUpdateCoordinator[MieleLanData]):
             except ValueError:
                 return MieleAppliance.UNKNOWN
         return MieleAppliance.UNKNOWN
+
+    @property
+    def protocol_version(self) -> int | None:
+        """Miele's DOP-generation enum from /Ident (2 = legacy Dop1, 3/4 = DOP2).
+
+        None until /Ident has loaded. Coerced the same way as `device_type`
+        above, because /Ident is inconsistent about whether its numeric
+        fields arrive as ints or as digit strings.
+        """
+        raw = (self._data.ident or {}).get("protocol_version")
+        if isinstance(raw, int):
+            return raw
+        if isinstance(raw, str) and raw.isdigit():
+            return int(raw)
+        return None
+
+    @property
+    def hood_dop1_supported(self) -> bool:
+        """Whether this appliance takes the hood Dop1 writes (fan, light, settings).
+
+        Mirrors the gate the official Miele app applies: the Dop1 action
+        variants declare themselves supported for ProtocolVersion == 2, and
+        the struct layouts in const.py are hood-specific. On a 3/4 hood the
+        app would route to a DOP2 mechanism we haven't confirmed, so those
+        appliances keep read-only ventilation telemetry and the /State light.
+        """
+        return self.device_type is MieleAppliance.HOOD and self.protocol_version == 2
 
     @property
     def hours_of_operation_supported(self) -> bool:
@@ -155,11 +196,26 @@ class MieleLanCoordinator(DataUpdateCoordinator[MieleLanData]):
             state = await self.client.get_state()
             self._data.state = dict(state.raw_state)
             if not self._ident_loaded:
-                self._data.ident = await self._fetch_full_ident()
-                self._ident_loaded = True
+                ident = await self._fetch_full_ident()
+                self._data.ident = ident
+                self._ident_attempts += 1
+                # Retry-on-empty, same reasoning as _maybe_refresh_wlan: a
+                # transient failure on the very first fetch would otherwise
+                # latch a permanently-empty ident, and entities gated on
+                # device_type / protocol_version (the hood fan) would never
+                # be created for the rest of the HA run. Give up after a few
+                # tries so an appliance that simply never reports these
+                # fields doesn't re-fetch /Ident on every poll forever.
+                if (
+                    ident.get("device_type")
+                    or ident.get("protocol_version") is not None
+                    or self._ident_attempts >= IDENT_MAX_ATTEMPTS
+                ):
+                    self._ident_loaded = True
             await self._maybe_refresh_wlan()
             await self._maybe_refresh_hours_of_operation()
             await self._maybe_refresh_device_context()
+            await self._maybe_refresh_hood_filters()
         except Exception as err:  # noqa: BLE001
             raise UpdateFailed(str(err)) from err
         return self._data
@@ -260,6 +316,51 @@ class MieleLanCoordinator(DataUpdateCoordinator[MieleLanData]):
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug("[%s] DOP2 2/1585 parse failed: %s", self.fab, err)
 
+    async def _maybe_refresh_hood_filters(self) -> None:
+        """Read the hood's grease/charcoal filter saturation grades.
+
+        Both come from the generic Dop1 Programmierfunktion object rather than
+        DOP2, so this is gated on `hood_dop1_supported`. Grades are 0..4
+        against the appliance's own DA_*FILTER_BST_GRENZE thresholds.
+
+        Results land in `dop2` to reuse the existing DOP2 sensor plumbing.
+        A hood with no charcoal filter fitted simply won't answer for that
+        one; only when *neither* grade comes back do we latch off, since that
+        means this firmware doesn't expose filter grades at all and further
+        reads would be pure noise.
+        """
+        if self._hood_filters_unsupported or not self.hood_dop1_supported:
+            return
+        now = time.monotonic()
+        # Throttle once we hold *either* grade — a hood with no charcoal
+        # filter fitted only ever reports the grease one, and keying the
+        # throttle on grease alone would re-read every poll on a hood that
+        # happens to report only charcoal.
+        have_grade = any(
+            self._data.dop2.get(k) is not None
+            for k in ("grease_filter_grade", "charcoal_filter_grade")
+        )
+        if have_grade and now - self._hood_filters_last_fetch < HOOD_FILTER_REFRESH_INTERVAL:
+            return
+        self._hood_filters_last_fetch = now
+        try:
+            grease = await self.client.read_setting_pf(PF_DA_FETTFILTER_GRENZE_AKTUELL)
+            charcoal = await self.client.read_setting_pf(PF_DA_KOHLEFILTER_GRENZE_AKTUELL)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("[%s] hood filter settings read failed: %s", self.fab, err)
+            return
+        if grease is None and charcoal is None:
+            self._hood_filters_unsupported = True
+            _LOGGER.debug(
+                "[%s] hood exposes no filter saturation grades — disabling those reads",
+                self.fab,
+            )
+            return
+        if grease is not None:
+            self._data.dop2["grease_filter_grade"] = grease
+        if charcoal is not None:
+            self._data.dop2["charcoal_filter_grade"] = charcoal
+
     async def _fetch_wlan(self) -> dict[str, Any]:
         """Read `/WLAN/` once at first refresh. The device exposes its current
         WiFi config + RSSI/signal-strength here (no auth needed beyond the
@@ -343,6 +444,7 @@ class MieleLanCoordinator(DataUpdateCoordinator[MieleLanData]):
             "xkm_tech_type": "",
             "xkm_fab_number": "",
             "xkm_release_version": "",
+            "protocol_version": None,
         }
         try:
             _, raw = await self.client.raw._request_bytes(
@@ -362,6 +464,7 @@ class MieleLanCoordinator(DataUpdateCoordinator[MieleLanData]):
                     "xkm_tech_type": xkm_label.get("TechType", ""),
                     "xkm_fab_number": xkm_label.get("FabNumber", ""),
                     "xkm_release_version": xkm_label.get("ReleaseVersion", ""),
+                    "protocol_version": data.get("ProtocolVersion"),
                 }
             )
         except Exception as err:  # noqa: BLE001

--- a/custom_components/miele_lan/fan.py
+++ b/custom_components/miele_lan/fan.py
@@ -1,0 +1,104 @@
+"""Miele@LAN fan — hood ventilation control over the legacy Dop1 protocol.
+
+Only created for hoods that take the Dop1 writes (see
+`MieleLanCoordinator.hood_dop1_supported` for the gate and const.py for the
+wire format). GLOBAL_USER_REQ, the mechanism every other control entity in
+this integration uses, answers HTTP 404 on these appliances, which is why
+ventilation needs its own path.
+
+Exposed as named presets rather than a percentage: the physical panel has
+discrete labeled steps, and "Boost" isn't the top of a linear scale, so
+mapping it onto 100% would misrepresent it. Turning the fan on takes a few
+seconds to show up in `/State.VentilationStep` while the motor spins up; the
+push channel delivers that update when it lands.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.fan import (
+    FanEntity,
+    FanEntityDescription,
+    FanEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import MieleLanCoordinator
+from .entity import MieleLanEntity
+
+# Luefterstufe -> preset label. Step 4 is labeled "Boost" on the appliance,
+# not "level 4". Step 5 (interval ventilation) is a real panel mode but isn't
+# offered here — it's untested over this write path, so it's reported as "no
+# recognized preset" rather than given a label we can't actually set.
+LEVEL_TO_PRESET: dict[int, str] = {1: "1", 2: "2", 3: "3", 4: "boost"}
+PRESET_TO_LEVEL: dict[str, int] = {v: k for k, v in LEVEL_TO_PRESET.items()}
+PRESET_MODES: list[str] = list(LEVEL_TO_PRESET.values())
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    bundle = hass.data[DOMAIN][entry.entry_id]
+    coordinators: dict[str, MieleLanCoordinator] = bundle["coordinators"]
+    entities: list[Any] = []
+    for coord in coordinators.values():
+        state = coord.data.state if coord.data else {}
+        if coord.hood_dop1_supported and "VentilationStep" in state:
+            entities.append(MieleLanFan(coord))
+    async_add_entities(entities)
+
+
+class MieleLanFan(MieleLanEntity, FanEntity):
+    """Hood ventilation fan."""
+
+    _attr_supported_features = (
+        FanEntityFeature.PRESET_MODE
+        | FanEntityFeature.TURN_ON
+        | FanEntityFeature.TURN_OFF
+    )
+    _attr_preset_modes = PRESET_MODES
+    entity_description = FanEntityDescription(
+        key="ventilation",
+        translation_key="ventilation",
+    )
+
+    def __init__(self, coordinator: MieleLanCoordinator) -> None:
+        super().__init__(coordinator, "ventilation")
+
+    @property
+    def _step(self) -> int | None:
+        if not self.coordinator.data:
+            return None
+        step = self.coordinator.data.state.get("VentilationStep")
+        return step if isinstance(step, int) else None
+
+    @property
+    def is_on(self) -> bool | None:
+        step = self._step
+        return None if step is None else step > 0
+
+    @property
+    def preset_mode(self) -> str | None:
+        return LEVEL_TO_PRESET.get(self._step or 0)
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        await self.coordinator.client.set_fan_level(PRESET_TO_LEVEL[preset_mode])
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        await self.async_set_preset_mode(preset_mode or PRESET_MODES[0])
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self.coordinator.client.set_fan_level(0)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/miele_lan/light.py
+++ b/custom_components/miele_lan/light.py
@@ -5,11 +5,15 @@ oven-family, coffee system, hood, wine cabinets, steam-microwave combos.
 
 State source: `/State.Light` (1 = on, 2 = off, 0 = unsupported).
 Writes: signed `PUT /State {"Light": 1|2}` — wrapped by
-`MieleLanClient.light_on()` / `light_off()`.
+`MieleLanClient.light_on()` / `light_off()`. Hoods that take the Dop1 writes
+use `set_main_light_dop1()` instead, which the appliance applies much faster
+(~0.8s vs ~4.9s to switch on, measured on an EK039W hood), falling back to
+/State if that write fails.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from homeassistant.components.light import ColorMode, LightEntity, LightEntityDescription
@@ -20,6 +24,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN, LIGHTABLE_FAMILY, MieleAppliance
 from .coordinator import MieleLanCoordinator
 from .entity import MieleLanEntity
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -60,10 +66,26 @@ class MieleLanLight(MieleLanEntity, LightEntity):
             return False
         return None  # 0 = unsupported / not yet known
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        await self.coordinator.client.light_on()
+    async def _set_light(self, on: bool) -> None:
+        client = self.coordinator.client
+        if self.coordinator.hood_dop1_supported:
+            try:
+                await client.set_main_light_dop1(on)
+            except Exception as err:  # noqa: BLE001
+                # A light that can't be switched is worse than a slow one, so
+                # any Dop1 failure falls through to the /State path that every
+                # other lightable appliance uses.
+                _LOGGER.warning(
+                    "Dop1 main-light write failed (%s) — falling back to /State", err
+                )
+            else:
+                await self.coordinator.async_request_refresh()
+                return
+        await (client.light_on() if on else client.light_off())
         await self.coordinator.async_request_refresh()
 
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self._set_light(True)
+
     async def async_turn_off(self, **kwargs: Any) -> None:
-        await self.coordinator.client.light_off()
-        await self.coordinator.async_request_refresh()
+        await self._set_light(False)

--- a/custom_components/miele_lan/select.py
+++ b/custom_components/miele_lan/select.py
@@ -1,0 +1,63 @@
+"""Miele@LAN select — hood fan run-on time (Nachlaufzeit).
+
+How long the extraction fan keeps running after it's switched off. Written
+over Dop1 (see const.py); the appliance offers exactly the discrete values in
+`RUN_ON_TIME_MINUTES`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, RUN_ON_TIME_MINUTES
+from .coordinator import MieleLanCoordinator
+from .entity import MieleLanEntity
+
+# "off" plus one option per nonzero run-on time, e.g. "5_min", "15_min".
+RUN_ON_OPTIONS: dict[str, int] = {
+    ("off" if m == 0 else f"{m}_min"): m for m in RUN_ON_TIME_MINUTES
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    bundle = hass.data[DOMAIN][entry.entry_id]
+    coordinators: dict[str, MieleLanCoordinator] = bundle["coordinators"]
+    entities: list[Any] = []
+    for coord in coordinators.values():
+        if coord.hood_dop1_supported:
+            entities.append(MieleLanFanRunOnSelect(coord))
+    async_add_entities(entities)
+
+
+class MieleLanFanRunOnSelect(MieleLanEntity, SelectEntity):
+    """Hood fan run-on time.
+
+    The appliance doesn't report this setting back in /State and the Dop1
+    read path only covers Programmierfunktionen, so the entity is optimistic:
+    it shows the last value written from Home Assistant, and stays unknown
+    until something sets it.
+    """
+
+    entity_description = SelectEntityDescription(
+        key="fan_run_on_time",
+        translation_key="fan_run_on_time",
+    )
+    _attr_options = list(RUN_ON_OPTIONS)
+
+    def __init__(self, coordinator: MieleLanCoordinator) -> None:
+        super().__init__(coordinator, "fan_run_on_time")
+        self._attr_current_option: str | None = None
+
+    async def async_select_option(self, option: str) -> None:
+        await self.coordinator.client.set_fan_run_on_time(RUN_ON_OPTIONS[option])
+        self._attr_current_option = option
+        self.async_write_ha_state()

--- a/custom_components/miele_lan/sensor.py
+++ b/custom_components/miele_lan/sensor.py
@@ -608,6 +608,22 @@ SENSOR_TYPES: tuple[MieleLanSensorDef, ...] = (
             value_fn=lambda s: {0: "not_supported", 1: "on", 2: "off"}.get(s.get("Light")),
         ),
     ),
+    # Hood extraction-fan step: 0 = off, 1-3 = speed, 4 = boost, 5 = interval.
+    # Kept as a sensor alongside the fan entity because the fan is only
+    # created for hoods that take the Dop1 writes (see fan.py), so this is
+    # the ventilation reading every other hood still gets — and it gives the
+    # writable ones long-term history the fan entity's preset can't.
+    MieleLanSensorDef(
+        types=(MieleAppliance.HOOD,),
+        description=MieleLanSensorDescription(
+            key="ventilation_step",
+            translation_key="ventilation_step",
+            icon="mdi:fan",
+            state_class=SensorStateClass.MEASUREMENT,
+            required_state_key="VentilationStep",
+            value_fn=lambda s: s.get("VentilationStep"),
+        ),
+    ),
 )
 
 
@@ -690,6 +706,33 @@ DOP2_SENSORS: tuple[MieleLanDop2SensorDef, ...] = (
                 if (v := (d.get("hours_of_operation") or {}).get("total")) is not None
                 else None
             ),
+        ),
+    ),
+    # Hood filter saturation grades (0..4 against the appliance's own
+    # thresholds). Read over Dop1 rather than DOP2 — see
+    # coordinator._maybe_refresh_hood_filters, which parks them in the same
+    # dict to reuse this plumbing. A hood with no charcoal filter fitted
+    # won't report that grade, so its sensor is simply not created.
+    MieleLanDop2SensorDef(
+        types=(MieleAppliance.HOOD,),
+        description=MieleLanDop2SensorDescription(
+            key="grease_filter_grade",
+            translation_key="grease_filter_grade",
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            required_dop2_key="grease_filter_grade",
+            value_fn=lambda d: d.get("grease_filter_grade"),
+        ),
+    ),
+    MieleLanDop2SensorDef(
+        types=(MieleAppliance.HOOD,),
+        description=MieleLanDop2SensorDescription(
+            key="charcoal_filter_grade",
+            translation_key="charcoal_filter_grade",
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            required_dop2_key="charcoal_filter_grade",
+            value_fn=lambda d: d.get("charcoal_filter_grade"),
         ),
     ),
 )
@@ -918,9 +961,13 @@ async def async_setup_entry(
         for d in DOP2_SENSORS:
             if dt not in d.types:
                 continue
-            if not coord.hours_of_operation_supported:
-                continue
             rdk = d.description.required_dop2_key
+            # `hours_of_operation_supported` tracks one specific DOP2 leaf
+            # (2/119) and says nothing about the other entries here — the hood
+            # filter grades don't even come from DOP2 (see coordinator.py) —
+            # so only the sensor fed by that leaf is gated on it.
+            if rdk == "hours_of_operation" and not coord.hours_of_operation_supported:
+                continue
             if rdk is not None and rdk not in coord.data.dop2:
                 continue
             entities.append(MieleLanDop2Sensor(coord, d.description))

--- a/custom_components/miele_lan/strings.json
+++ b/custom_components/miele_lan/strings.json
@@ -2075,6 +2075,15 @@
       },
       "plate_6_duration_minutes": {
         "name": "Cooking zone 6 duration"
+      },
+      "ventilation_step": {
+        "name": "Ventilation step"
+      },
+      "grease_filter_grade": {
+        "name": "Grease filter saturation"
+      },
+      "charcoal_filter_grade": {
+        "name": "Charcoal filter saturation"
       }
     },
     "binary_sensor": {
@@ -2161,6 +2170,31 @@
       },
       "stop_program": {
         "name": "Stop program"
+      }
+    },
+    "fan": {
+      "ventilation": {
+        "name": "Ventilation",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "1": "Level 1",
+              "2": "Level 2",
+              "3": "Level 3",
+              "boost": "Boost"
+            }
+          }
+        }
+      }
+    },
+    "select": {
+      "fan_run_on_time": {
+        "name": "Fan run-on time",
+        "state": {
+          "off": "Off",
+          "5_min": "5 minutes",
+          "15_min": "15 minutes"
+        }
       }
     }
   },

--- a/custom_components/miele_lan/translations/de.json
+++ b/custom_components/miele_lan/translations/de.json
@@ -2085,6 +2085,15 @@
       },
       "plate_6_duration_minutes": {
         "name": "Kochzone 6 Programm-Dauer"
+      },
+      "ventilation_step": {
+        "name": "Lüfterstufe"
+      },
+      "grease_filter_grade": {
+        "name": "Fettfilter-Sättigung"
+      },
+      "charcoal_filter_grade": {
+        "name": "Kohlefilter-Sättigung"
       }
     },
     "binary_sensor": {
@@ -2177,6 +2186,31 @@
       },
       "stop_program": {
         "name": "Programm stoppen"
+      }
+    },
+    "fan": {
+      "ventilation": {
+        "name": "Lüfter",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "1": "Stufe 1",
+              "2": "Stufe 2",
+              "3": "Stufe 3",
+              "boost": "Intensivstufe"
+            }
+          }
+        }
+      }
+    },
+    "select": {
+      "fan_run_on_time": {
+        "name": "Lüfter-Nachlaufzeit",
+        "state": {
+          "off": "Aus",
+          "5_min": "5 Minuten",
+          "15_min": "15 Minuten"
+        }
       }
     }
   },

--- a/custom_components/miele_lan/translations/en.json
+++ b/custom_components/miele_lan/translations/en.json
@@ -2075,6 +2075,15 @@
       },
       "plate_6_duration_minutes": {
         "name": "Cooking zone 6 duration"
+      },
+      "ventilation_step": {
+        "name": "Ventilation step"
+      },
+      "grease_filter_grade": {
+        "name": "Grease filter saturation"
+      },
+      "charcoal_filter_grade": {
+        "name": "Charcoal filter saturation"
       }
     },
     "binary_sensor": {
@@ -2167,6 +2176,31 @@
       },
       "stop_program": {
         "name": "Stop program"
+      }
+    },
+    "fan": {
+      "ventilation": {
+        "name": "Ventilation",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "1": "Level 1",
+              "2": "Level 2",
+              "3": "Level 3",
+              "boost": "Boost"
+            }
+          }
+        }
+      }
+    },
+    "select": {
+      "fan_run_on_time": {
+        "name": "Fan run-on time",
+        "state": {
+          "off": "Off",
+          "5_min": "5 minutes",
+          "15_min": "15 minutes"
+        }
       }
     }
   },

--- a/tests/test_dop1_hood_client.py
+++ b/tests/test_dop1_hood_client.py
@@ -1,0 +1,120 @@
+"""Tests for the Dop1 hood write/read methods on MieleLanClient.
+
+No HA, no network — the underlying client is a stub that records the request
+it was handed and can be told to fail with a given HTTP status.
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from asyncmiele.exceptions.network import ResponseError  # noqa: E402
+from homeassistant.exceptions import HomeAssistantError  # noqa: E402
+
+from custom_components.miele_lan.api import MieleLanClient  # noqa: E402
+from custom_components.miele_lan.const import (  # noqa: E402
+    PF_DA_FETTFILTER_GRENZE_AKTUELL,
+)
+
+FAB = "000000000000"
+
+
+class _StubRawClient:
+    """Records calls; optionally raises ResponseError or returns a body."""
+
+    def __init__(self, *, status_code: int | None = None, body: bytes = b"") -> None:
+        self._status_code = status_code
+        self._body = body
+        self.calls: list[tuple[str, str, dict | None]] = []
+
+    async def _request_bytes(self, method, resource, *, body=None, allowed_status=(200,)):
+        self.calls.append((method, resource, body))
+        if self._status_code is not None:
+            raise ResponseError(self._status_code, "stub failure")
+        return 200, self._body
+
+
+def _client(**kwargs) -> tuple[MieleLanClient, _StubRawClient]:
+    raw = _StubRawClient(**kwargs)
+    return MieleLanClient(raw, route=FAB), raw
+
+
+# --------------------------------------------------------------- transport
+def test_fan_level_posts_to_the_dop1_endpoint() -> None:
+    client, raw = _client()
+    asyncio.run(client.set_fan_level(2))
+    method, resource, body = raw.calls[0]
+    assert method == "POST"
+    assert resource == f"/Devices/{FAB}/DOP/"
+    assert body == {"Request": "8E01020000FF0200"}
+
+
+def test_run_on_time_and_main_light_use_the_same_endpoint() -> None:
+    client, raw = _client()
+    asyncio.run(client.set_fan_run_on_time(15))
+    asyncio.run(client.set_main_light_dop1(True))
+    assert {resource for _, resource, _ in raw.calls} == {f"/Devices/{FAB}/DOP/"}
+    assert raw.calls[0][2] == {"Request": "8E060200000F"}
+    assert raw.calls[1][2]["Request"].startswith("14000200")
+
+
+def test_write_setting_pf_sends_the_write_request_type() -> None:
+    client, raw = _client()
+    asyncio.run(client.write_setting_pf(PF_DA_FETTFILTER_GRENZE_AKTUELL, 1))
+    assert raw.calls[0][2] == {"Request": "12010200009C4A00000001"}
+
+
+# ------------------------------------------------------- error conventions
+def test_http_400_is_treated_as_a_benign_no_op() -> None:
+    """Re-asserting the current value must not surface as an error."""
+    client, _ = _client(status_code=400)
+    asyncio.run(client.set_fan_level(1))  # no raise
+    asyncio.run(client.set_main_light_dop1(False))  # no raise
+    assert asyncio.run(client.read_setting_pf(PF_DA_FETTFILTER_GRENZE_AKTUELL)) is None
+
+
+@pytest.mark.parametrize("status", [403, 404, 500])
+def test_other_http_errors_surface_as_home_assistant_errors(status: int) -> None:
+    client, _ = _client(status_code=status)
+    with pytest.raises(HomeAssistantError) as exc_info:
+        asyncio.run(client.set_fan_level(1))
+    message = str(exc_info.value)
+    assert "Fan level write" in message
+    assert str(status) in message
+
+
+def test_invalid_values_are_rejected_before_any_request_is_made() -> None:
+    client, raw = _client()
+    with pytest.raises(ValueError):
+        asyncio.run(client.set_fan_level(9))
+    with pytest.raises(ValueError):
+        asyncio.run(client.set_fan_run_on_time(7))
+    assert raw.calls == []
+
+
+# ------------------------------------------------------------ setting reads
+def test_read_setting_pf_extracts_the_value_from_the_json_response() -> None:
+    pf = PF_DA_FETTFILTER_GRENZE_AKTUELL
+    response_hex = f"1201010000{pf:04X}{3:08X}{0:08X}{4:08X}"
+    body = json.dumps({"Response": response_hex}).encode()
+    client, _ = _client(body=body)
+    assert asyncio.run(client.read_setting_pf(pf)) == 3
+
+
+def test_read_setting_pf_returns_none_for_an_empty_body() -> None:
+    client, _ = _client(body=b"")
+    assert asyncio.run(client.read_setting_pf(PF_DA_FETTFILTER_GRENZE_AKTUELL)) is None
+
+
+def test_read_setting_pf_returns_none_when_the_appliance_answers_about_another_setting() -> None:
+    other = PF_DA_FETTFILTER_GRENZE_AKTUELL + 1
+    response_hex = f"1201010000{other:04X}{2:08X}{0:08X}{4:08X}"
+    body = json.dumps({"Response": response_hex}).encode()
+    client, _ = _client(body=body)
+    assert asyncio.run(client.read_setting_pf(PF_DA_FETTFILTER_GRENZE_AKTUELL)) is None

--- a/tests/test_dop1_hood_payloads.py
+++ b/tests/test_dop1_hood_payloads.py
@@ -1,0 +1,148 @@
+"""Pure-Python tests for the Dop1 hood request builders. No HA / network.
+
+The hex strings asserted here are the ones the appliance actually accepts, so
+they double as a record of the wire format documented in const.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from custom_components.miele_lan.api import (  # noqa: E402
+    build_dop1_fan_level_request,
+    build_dop1_main_light_request,
+    build_dop1_run_on_time_request,
+    build_dop1_setting_pf_read_request,
+    build_dop1_setting_pf_write_request,
+    parse_dop1_setting_pf_value,
+)
+from custom_components.miele_lan.const import (  # noqa: E402
+    PF_DA_FETTFILTER_GRENZE_AKTUELL,
+    RUN_ON_TIME_MINUTES,
+)
+
+
+# --- ventilation ------------------------------------------------------------
+
+def test_fan_level_matches_capture() -> None:
+    # 8E01 + write(02) + 00 + [version=0, selection=0xFF, level, power=0]
+    assert build_dop1_fan_level_request(0) == "8E010200" + "00FF0000"
+    assert build_dop1_fan_level_request(1) == "8E010200" + "00FF0100"
+    assert build_dop1_fan_level_request(4) == "8E010200" + "00FF0400"
+
+
+def test_fan_level_section_is_four_bytes() -> None:
+    for level in range(6):
+        assert len(build_dop1_fan_level_request(level)) == 8 + 8
+
+
+def test_fan_level_rejects_out_of_range() -> None:
+    for bad in (-1, 6, 255):
+        with pytest.raises(ValueError):
+            build_dop1_fan_level_request(bad)
+
+
+# --- run-on time ------------------------------------------------------------
+
+def test_run_on_time_matches_capture() -> None:
+    # 8E06 + write(02) + 00 + [version=0, minutes]
+    assert build_dop1_run_on_time_request(0) == "8E060200" + "0000"
+    assert build_dop1_run_on_time_request(5) == "8E060200" + "0005"
+    assert build_dop1_run_on_time_request(15) == "8E060200" + "000F"
+
+
+def test_run_on_time_rejects_values_the_appliance_does_not_offer() -> None:
+    for bad in (1, 10, 20, -5):
+        assert bad not in RUN_ON_TIME_MINUTES
+        with pytest.raises(ValueError):
+            build_dop1_run_on_time_request(bad)
+
+
+# --- main light -------------------------------------------------------------
+
+def test_main_light_on_matches_capture() -> None:
+    # 1400 + write(02) + 00 + [version=2, source=1, mode=4(cooking),
+    #                          RGB=0, WW=0xFFFF, KW=0]
+    assert build_dop1_main_light_request(True) == "14000200" + "020104000000000000FFFF0000"
+
+
+def test_main_light_off_matches_capture() -> None:
+    # mode=0 (off) and WW dimmed back to 0
+    assert build_dop1_main_light_request(False) == "14000200" + "02010000000000000000000000"
+
+
+def test_main_light_section_is_thirteen_bytes() -> None:
+    for on in (True, False):
+        assert len(build_dop1_main_light_request(on)) - 8 == 13 * 2
+
+
+# --- Programmierfunktion settings ------------------------------------------
+
+def test_setting_pf_write_matches_capture() -> None:
+    # 1201 + write(02) + 00 + [version=0, PF_ID u16 BE, value u32 BE]
+    # 40010 == 0x9C4A
+    assert (
+        build_dop1_setting_pf_write_request(PF_DA_FETTFILTER_GRENZE_AKTUELL, 1)
+        == "12010200" + "009C4A00000001"
+    )
+
+
+def test_setting_pf_read_matches_capture() -> None:
+    # Read request carries only version + PF_ID; note the read type byte (01).
+    assert (
+        build_dop1_setting_pf_read_request(PF_DA_FETTFILTER_GRENZE_AKTUELL)
+        == "12010100" + "009C4A"
+    )
+
+
+def test_setting_pf_rejects_out_of_range() -> None:
+    with pytest.raises(ValueError):
+        build_dop1_setting_pf_write_request(0x10000, 0)
+    with pytest.raises(ValueError):
+        build_dop1_setting_pf_write_request(1, 0x1_0000_0000)
+    with pytest.raises(ValueError):
+        build_dop1_setting_pf_read_request(-1)
+
+
+# --- Programmierfunktion response parsing ----------------------------------
+
+def _pf_response(pf_id: int, value: int, *, prefix: str = "12010100") -> str:
+    """Build a read response: framing prefix + version, PF_ID, Wert, Min, Max."""
+    return (
+        f"{prefix}00{pf_id:04X}{value:08X}{0:08X}{4:08X}"
+    )
+
+
+def test_parse_reads_the_value_after_the_echoed_pf_id() -> None:
+    assert parse_dop1_setting_pf_value(_pf_response(40010, 2), 40010) == 2
+    assert parse_dop1_setting_pf_value(_pf_response(40011, 0), 40011) == 0
+
+
+def test_parse_is_case_insensitive_and_tolerates_whitespace() -> None:
+    hex_str = _pf_response(40010, 3)
+    assert parse_dop1_setting_pf_value(f"  {hex_str.lower()}  ", 40010) == 3
+
+
+def test_parse_returns_none_when_the_pf_is_absent() -> None:
+    # Appliance answered about a different setting — no value for ours.
+    assert parse_dop1_setting_pf_value(_pf_response(40011, 2), 40010) is None
+
+
+def test_parse_returns_none_when_the_read_section_is_truncated() -> None:
+    # PF_ID present but Wert/Min/Max don't fit — not a real read section.
+    assert parse_dop1_setting_pf_value("009C4A0000", 40010) is None
+
+
+def test_parse_skips_a_match_that_is_not_byte_aligned() -> None:
+    # 0x9C4A appearing straddled across a byte boundary must not be mistaken
+    # for the echoed PF_ID; the real, aligned occurrence wins.
+    straddled = "F9C4A0" + _pf_response(40010, 7)
+    assert parse_dop1_setting_pf_value(straddled, 40010) == 7
+
+
+def test_parse_returns_none_on_odd_length_hex() -> None:
+    assert parse_dop1_setting_pf_value("009C4A00000001F", 40010) is None


### PR DESCRIPTION
## What this does

Hoods are currently read-only apart from the light. This adds local ventilation control, fan run-on time, and filter-saturation sensors.

The reason hood control needed a new mechanism: the DOP2 `GLOBAL_USER_REQ` path that every other control entity here uses answers **HTTP 404** on these appliances. The official Miele app doesn't use it either — its action providers try `[Dop1, OpCode, Dop2, Default]` in order, and the Dop1 variants declare themselves supported for `ProtocolVersion == 2`, so on a ProtocolVersion 2 hood the app never reaches the DOP2 path at all.

So this implements that same Dop1 mechanism: a signed `POST /Devices/{fab}/DOP/` carrying `{"Request": "<ObjectId><RequestType>00<struct>"}`.

## New entities

| Entity | Notes |
|---|---|
| `fan.<hood>_ventilation` | off / 1 / 2 / 3 / boost |
| `select.<hood>_fan_run_on_time` | off / 5 min / 15 min |
| `sensor.<hood>_ventilation_step` | read-only fan step, **every** hood |
| `sensor.<hood>_grease_filter_saturation` | grade 0..4, diagnostic |
| `sensor.<hood>_charcoal_filter_saturation` | grade 0..4, diagnostic |

`light.<hood>_light` keeps working exactly as before, but now prefers the Dop1 `SwitchLight_W` write on hoods, which the appliance applies far faster — **~0.8s vs ~4.9s** to switch on, measured on an EK039W. Any Dop1 failure falls back to the `/State` path, so the light can never end up uncontrollable.

A few deliberate choices worth flagging for review:

- **Presets, not a percentage.** The panel has discrete labeled steps and "boost" isn't the top of a linear scale, so mapping it onto 100% would misrepresent it. (HA's official cloud `miele` integration models the same hardware as a 4-step percentage; this seemed more faithful for a local entity, but happy to switch if you'd rather the two matched.)
- **The step sensor is kept alongside the fan entity.** The fan is only created for hoods that take the Dop1 writes, so the sensor is the ventilation reading every *other* hood still gets — and it gives the writable ones long-term history that the fan's preset attribute can't.
- **Run-on time is optimistic.** The appliance doesn't report the setting back in `/State`, so the select shows the last value written and stays unknown until something sets it.
- **Interval ventilation (step 5)** is a real panel mode but is reported, not offered — it's untested over this write path, so it shows as "no recognized preset" rather than a label that can't actually be set.

## Gating

Every Dop1 write and read goes through `coordinator.hood_dop1_supported`, which mirrors the app's own check: `device_type is HOOD and protocol_version == 2`. Hoods reporting ProtocolVersion 3/4 would route to a DOP2 mechanism I haven't been able to confirm, so they keep the read-only step sensor and the `/State` light — no behaviour change for them, and nothing new is attempted against them.

## Two supporting fixes this needed

1. **`/Ident` now carries `ProtocolVersion`**, and a first fetch that comes back without the fields entities gate on is retried rather than latching a permanently-empty ident (which would silently starve the hood fan for the rest of the HA run). Bounded to 5 attempts so an appliance that simply never reports those fields doesn't re-fetch `/Ident` on every poll forever.

2. **The DOP2 sensor loop no longer gates every entry on `hours_of_operation_supported`.** That flag tracks leaf 2/119 alone, and the filter grades don't come from DOP2 at all — this continues the decoupling started in a3f6889. Only the sensor actually fed by that leaf is gated on it now; behaviour for ovens is unchanged.

## Wire format

Object layouts are documented per-object in `const.py` (Lueftersteuerung `8E01`, Nachlaufzeit `8E06`, SwitchLight_W `1400`, Setting_PF `1201`), recovered from the app's own action classes and then confirmed against real hardware.

The request builders are pure functions, so the wire format is covered by tests without needing hardware:

- `tests/test_dop1_hood_payloads.py` — asserts the exact hex the appliance accepts, plus range rejection and the read-response parser (byte alignment, truncation, wrong-setting answers).
- `tests/test_dop1_hood_client.py` — endpoint/body/error conventions against a stub client, including HTTP 400 being treated as the benign no-op this firmware uses when you re-assert the current value.

## Testing

- `pytest tests/ -q` → **114 passed** (was 88; 26 new).
- Running on a real hood: fan through every step and off, run-on time at all three values, light on/off, both filter grades reading.
- Ventilation state changes arrive over the push channel. Turning the fan **on** takes ~4s to show up in `/State.VentilationStep` while the motor spins up; **off** is near-instant. No keep-alive signal is needed.

## Not included

The RE also turned up write PFs for grease/charcoal filter **counter resets** (40012/40013) and interval-ventilation enable (40023). Those are writes I haven't tested, so I've left them out rather than ship untested buttons — happy to follow up with them separately if you'd like them.

## Notes

- No version bump — semantic-release handles that.
- `hassfest` translation keys added to `strings.json`, `translations/en.json` and `translations/de.json`, verified to cover every preset and option the entities offer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
