### PR TITLE
feat(coordinator): Log raw /State contents at debug level

### DIFF
--- a/custom_components/miele_lan/coordinator.py
+++ b/custom_components/miele_lan/coordinator.py
@@ -36,6 +36,7 @@ from .dop2 import parse_global_device_context, parse_hours_of_operation
 from .enrollment import EnrolledDevice
 from .polling import POLL_FALLBACK_INTERVAL, decide_poll_interval
 from .push_listener import PushEvent
+from .state_debug_log import render_state_for_log
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -197,6 +198,10 @@ class MieleLanCoordinator(DataUpdateCoordinator[MieleLanData]):
         try:
             state = await self.client.get_state()
             self._data.state = dict(state.raw_state)
+            _LOGGER.debug(
+                "[%s] polled /State: %s",
+                self.fab, render_state_for_log(self._data.state),
+            )
             if not self._ident_loaded:
                 ident = await self._fetch_full_ident()
                 self._data.ident = ident
@@ -432,6 +437,10 @@ class MieleLanCoordinator(DataUpdateCoordinator[MieleLanData]):
                 _LOGGER.info(
                     "[%s] push merged %d field(s) into /State; changed=%s",
                     self.fab, len(event.content), list(changed.keys()),
+                )
+                _LOGGER.debug(
+                    "[%s] push /State content: %s",
+                    self.fab, render_state_for_log(event.content),
                 )
                 merged = True
             else:

--- a/custom_components/miele_lan/state_debug_log.py
+++ b/custom_components/miele_lan/state_debug_log.py
@@ -1,0 +1,30 @@
+"""Rendering for the raw `/State` debug-log lines.
+
+No Home Assistant imports — kept separate from coordinator.py so the
+rendering (stable ordering, size cap, truncation marker) can be
+unit-tested directly, same pattern as polling.py and enrollment_report.py.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+STATE_LOG_MAX_CHARS = 4000
+
+
+def render_state_for_log(state: dict[str, Any], *, max_chars: int = STATE_LOG_MAX_CHARS) -> str:
+    """Render a `/State` (or push Content) dict for a debug-log line.
+
+    Keys are sorted so two renders taken at different moments can be diffed
+    by eye, and the result is capped at `max_chars` so a pathological
+    payload can't dump unbounded text into someone's log — the cut is
+    marked explicitly rather than silently truncating mid-value.
+    """
+    rendered = json.dumps(state, sort_keys=True, default=str)
+    if len(rendered) <= max_chars:
+        return rendered
+    return f"{rendered[:max_chars]}...<truncated, {len(rendered)} chars total>"
+
+
+__all__ = ["STATE_LOG_MAX_CHARS", "render_state_for_log"]

--- a/tests/test_state_debug_log.py
+++ b/tests/test_state_debug_log.py
@@ -1,0 +1,71 @@
+"""Tests for the raw `/State` debug-log rendering helper.
+
+`state_debug_log.py` is loaded straight off disk, same as `polling.py` in
+test_polling.py — it has zero relative imports, so this stays free of any
+`homeassistant` dependency.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+_spec = importlib.util.spec_from_file_location(
+    "miele_lan_state_debug_log",
+    ROOT / "custom_components" / "miele_lan" / "state_debug_log.py",
+)
+state_debug_log = importlib.util.module_from_spec(_spec)
+sys.modules["miele_lan_state_debug_log"] = state_debug_log
+_spec.loader.exec_module(state_debug_log)
+
+
+def test_empty_dict_renders_sensibly() -> None:
+    assert state_debug_log.render_state_for_log({}) == "{}"
+
+
+def test_output_is_valid_json_round_trip() -> None:
+    state = {"Status": {"value_raw": 5}, "RemainingTime": [0, 30]}
+    rendered = state_debug_log.render_state_for_log(state)
+    assert json.loads(rendered) == state
+
+
+def test_key_order_is_stable_regardless_of_insertion_order() -> None:
+    a = {"b": 1, "a": 2, "c": 3}
+    b = {"c": 3, "a": 2, "b": 1}
+    assert state_debug_log.render_state_for_log(a) == state_debug_log.render_state_for_log(b)
+
+
+def test_key_order_is_sorted() -> None:
+    state = {"z": 1, "a": 2, "m": 3}
+    rendered = state_debug_log.render_state_for_log(state)
+    assert rendered.index('"a"') < rendered.index('"m"') < rendered.index('"z"')
+
+
+def test_small_payload_is_not_truncated() -> None:
+    state = {"Status": {"value_raw": 5}}
+    rendered = state_debug_log.render_state_for_log(state)
+    assert "truncated" not in rendered
+
+
+def test_oversized_payload_is_capped_and_marked() -> None:
+    state = {"Payload": "x" * 10_000}
+    rendered = state_debug_log.render_state_for_log(state, max_chars=100)
+    assert len(rendered) > 100
+    assert rendered.startswith('{"Payload": "' + "x" * 10)
+    assert "...<truncated, " in rendered
+    assert rendered.endswith(" chars total>")
+
+
+def test_truncation_respects_custom_max_chars() -> None:
+    state = {"a": "y" * 1000}
+    rendered = state_debug_log.render_state_for_log(state, max_chars=50)
+    body_before_marker = rendered.split("...<truncated,")[0]
+    assert len(body_before_marker) == 50
+
+
+def test_non_json_native_values_are_stringified() -> None:
+    state = {"fab": "000000000000", "seen_at": object()}
+    rendered = state_debug_log.render_state_for_log(state)
+    assert "000000000000" in rendered


### PR DESCRIPTION
Three open issues are stuck at the same step: an appliance leaves some sensors empty, and the next question is always "what does your appliance actually put in `/State`?" — because the integration reads specific keys in specific shapes (`RemainingTime` as `[hours, minutes]`, and so on).

There was no way to answer that. The coordinator logged fetch timings; the push path logged only the *names* of the keys a push carried, never their values. So reporters were asked to enable debug logging and paste "the raw `/State` line", and one of them enabled debug, captured a full log, and replied that no such line exists. He was right.

## What this adds

Two debug-level lines, both tagged with the fab like everything else in that file:

```
[000000000000] polled /State: {"ProgramID": 4, "RemainingTime": [0, 45], "Status": 5}
[000000000000] push /State content: {"RemainingTime": [0, 44], "Status": 5}
```

The existing INFO line naming the *changed* keys on a push is untouched; the values now follow it at debug.

That is enough to tell three cases apart that currently look identical from the outside: the appliance never sends the field, it sends it under a different key, or it sends it in a shape the parser does not expect.

## Rendering

`render_state_for_log()` lives in its own module with no Home Assistant imports, so it is unit-tested directly — the same pattern as `polling.py` and `enrollment_report.py`.

- **Sorted keys**, so two captures taken minutes apart can be diffed by eye.
- **Capped at 4000 characters** with an explicit `...<truncated, N chars total>` marker — a pathological payload cannot dump unbounded text into someone's log, and a cut is never silent.
- `default=str`, so an unexpected value type renders instead of raising inside a log call.

Only `/State` values pass through it. Nothing from `/Ident`, `/WLAN`, request headers, or any credential — the GroupID and GroupKey never appear.

## One honest note on cost

The log calls use lazy `%s` formatting, so the *string interpolation* only happens when a debug handler is attached. The `render_state_for_log()` call itself is an argument, so it does run on every poll regardless of level. That is a `json.dumps` of a dict of a few hundred bytes, once per appliance per poll, which is not worth a guard clause — but it is not free, and the PR should say so rather than imply otherwise.

## Verification

- `pytest tests/ -q` → **140 passed** (132 + 8 new: stable ordering, the truncation marker and its character count, empty dict, non-serialisable values).
- Confirmed by running the helper directly: `{}` renders as `{}`, keys come out sorted, and an oversized payload ends in `...<truncated, 5009 chars total>`.
- Confirmed nothing new is emitted at INFO or above.