### PR TITLE
fix(switch): Stop creating hood power switch on Dop1-capable hoods

### DIFF
--- a/custom_components/miele_lan/const.py
+++ b/custom_components/miele_lan/const.py
@@ -283,6 +283,26 @@ POWERABLE_FAMILY: tuple[MieleAppliance, ...] = (
 )
 
 
+def wants_power_switch(device_type: MieleAppliance, *, hood_dop1_supported: bool) -> bool:
+    """Whether `device_type` should get the DOP2 power switch entity.
+
+    Every other POWERABLE_FAMILY member accepts the switch's DOP2 write
+    (leaf 2/1583). Dop1-capable hoods (ProtocolVersion 2) are the one
+    exception: GLOBAL_USER_REQ answers 404 on them outright (see the
+    DOP1_* leaf comment above), and the fan entity already covers on/off
+    via `set_fan_level(0)` — a second, permanently-broken entity would
+    only confuse users. Non-Dop1 hoods (ProtocolVersion 3/4) get no fan
+    entity at all, and we have no evidence either way on whether they
+    accept the DOP2 write, so they keep the switch rather than lose their
+    only remaining power control.
+    """
+    if device_type not in POWERABLE_FAMILY:
+        return False
+    if device_type is MieleAppliance.HOOD:
+        return not hood_dop1_supported
+    return True
+
+
 # Known-good DOP2 leaves on the H7560BP, per protocol_findings memory.
 LEAF_DEVICE_COMBINED_STATE = (2, 1586)   # 24 B — modern
 LEAF_DEVICE_COMBINED_LEGACY = (2, 256)   # 232 B — deprecated alias

--- a/custom_components/miele_lan/switch.py
+++ b/custom_components/miele_lan/switch.py
@@ -1,7 +1,8 @@
 """Miele@LAN switches — per-device-type filtered.
 
 * **Power** (oven-family / dishwasher / coffee-system / etc.) maps
-  `Status != 1 (Off)` ↔ DOP2 SWITCH_ON / SWITCH_OFF opcodes.
+  `Status != 1 (Off)` ↔ DOP2 SWITCH_ON / SWITCH_OFF opcodes. Dop1-capable
+  hoods are excluded — see `const.wants_power_switch`.
 
 Cooling-family SuperCool/SuperFreeze are NOT switches — see binary_sensor.py.
 Confirmed 2026-05-22: the K7000 / EK057* fridge firmware blocks LAN writes
@@ -33,6 +34,7 @@ from .const import (
     DOMAIN,
     POWERABLE_FAMILY,
     MieleAppliance,
+    wants_power_switch,
 )
 from .coordinator import MieleLanCoordinator
 from .entity import MieleLanEntity
@@ -78,7 +80,9 @@ async def async_setup_entry(
     for coord in coordinators.values():
         dt = coord.device_type
         for d in SWITCH_TYPES:
-            if dt in d.types:
+            if dt in d.types and wants_power_switch(
+                dt, hood_dop1_supported=coord.hood_dop1_supported
+            ):
                 entities.append(MieleLanSwitch(coord, d.description))
     async_add_entities(entities)
 

--- a/tests/test_switch_power_gate.py
+++ b/tests/test_switch_power_gate.py
@@ -1,0 +1,41 @@
+"""Tests for the hood power-switch gate (issue #39).
+
+Pure-Python — `wants_power_switch` has no Home Assistant imports, so this
+stays free of any `homeassistant` dependency, same as test_polling.py.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from custom_components.miele_lan.const import (  # noqa: E402
+    MieleAppliance,
+    wants_power_switch,
+)
+
+
+def test_dop1_hood_gets_no_power_switch() -> None:
+    """The fan entity already covers on/off; DOP2 write 404s on these hoods."""
+    assert wants_power_switch(MieleAppliance.HOOD, hood_dop1_supported=True) is False
+
+
+def test_non_dop1_hood_keeps_power_switch() -> None:
+    """No fan entity and no evidence the DOP2 write fails here — keep it."""
+    assert wants_power_switch(MieleAppliance.HOOD, hood_dop1_supported=False) is True
+
+
+def test_other_powerable_appliances_unaffected() -> None:
+    for device_type in (
+        MieleAppliance.OVEN,
+        MieleAppliance.DISHWASHER,
+        MieleAppliance.DISH_WARMER,
+        MieleAppliance.COFFEE_SYSTEM,
+    ):
+        assert wants_power_switch(device_type, hood_dop1_supported=True) is True
+        assert wants_power_switch(device_type, hood_dop1_supported=False) is True
+
+
+def test_non_powerable_appliance_gets_no_switch() -> None:
+    assert wants_power_switch(MieleAppliance.FRIDGE, hood_dop1_supported=False) is False


### PR DESCRIPTION
Closes #39.

Hoods got a power switch that could never work. It writes DOP2 leaf `2/1583`, and hoods answer 404 to that entire path — which is precisely why hood control had to go through the older Dop1 mechanism in the first place. A user confirmed it: everything else about hood control works on their DA2558, but the power switch still errors.

## Why this is narrower than removing HOOD from POWERABLE_FAMILY

That was the obvious fix and it over-corrects, because the fan entity is itself gated on `hood_dop1_supported`:

- **Dop1-capable hoods** (ProtocolVersion 2) have the fan entity, whose `off` calls `set_fan_level(0)`. On/off is covered, and the DOP2 write provably 404s. The switch is redundant *and* broken → not created.
- **Non-Dop1 hoods** (ProtocolVersion 3/4) get **no fan entity at all**, and we have no evidence about their DOP2 behaviour — every 404 observed came from a Dop1 hood. Removing their switch would take away a possibly-working control and leave them with only a light → keep it.

So the gate is Dop1 capability, not "is a hood". Same outcome for the person who reported it, without silently degrading an untested class of appliance.

Reimplementing hood power over Dop1 was considered and rejected: it would duplicate the fan entity as a second control doing the same job.

## Shape

A pure predicate in `const.py` next to `POWERABLE_FAMILY`:

```python
def wants_power_switch(device_type, *, hood_dop1_supported) -> bool
```

No Home Assistant imports, so the rule is unit-tested directly rather than through the platform — the `polling.py` / `enrollment_report.py` precedent. `HOOD` stays in `POWERABLE_FAMILY`; `fan.py` and the client are untouched.

## Breaking change for hood owners

A Dop1 hood loses `switch.<device_name>_power`. Pressing it has only ever raised an error, but anyone with an automation or dashboard card referencing it will see that break. Worth a line in the release notes rather than letting it be discovered.

## One thing a future reader should know

The gate is applied to every entry in `SWITCH_TYPES`, which today contains only the power switch. If a second switch type is ever added, it would inherit this hood exclusion by accident. Fine as it stands, worth remembering when that list grows.

## Verification

- `pytest tests/ -q` → **164 passed** (160 + 4 new: Dop1 hood, non-Dop1 hood, the other powerable families in both states, and a non-powerable device).
- Checked directly: `HOOD` → `False` when `hood_dop1_supported=True`, `True` when `False`; `OVEN` and `DISHWASHER` → `True` in both.