### PR TITLE
feat(button): Add start, stop, pause and resume over PUT /State

### DIFF
--- a/custom_components/miele_lan/api.py
+++ b/custom_components/miele_lan/api.py
@@ -57,7 +57,14 @@ from .const import (
     OPCODE_LIGHT_ON,
     OPCODE_SWITCH_OFF,
     OPCODE_SWITCH_ON,
+    PROCESS_ACTION_PAUSE,
+    PROCESS_ACTION_RESUME,
+    PROCESS_ACTION_START,
+    PROCESS_ACTION_STOP,
+    REMOTE_ENABLE_FULL_CONTROL_INDEX,
+    REMOTE_ENABLE_FULL_CONTROL_VALUE,
     RUN_ON_TIME_MINUTES,
+    STATUS_WAITING_TO_START,
     USER_REQUEST_LEAF,
     USER_REQUEST_UNIT,
 )
@@ -100,6 +107,44 @@ def build_user_request_payload(opcode: int) -> bytes:
     if not 0 <= opcode <= 0xFF:
         raise ValueError(f"opcode out of range: {opcode}")
     return _OVEN_REQ_PREFIX + bytes([opcode]) + _OVEN_REQ_SUFFIX
+
+
+def check_process_action_precondition(state: dict[str, Any], action: int) -> str | None:
+    """Whether a cached `/State` rules out a `ProcessAction` write before we send it.
+
+    Pure and I/O-free so it can be tested without a device. Returns ``None``
+    when nothing known here rules the write out — that is *not* a guarantee
+    of success: upstream has reports of Start being refused by the
+    appliance's physical control panel with every `/State` field already
+    correct, so a clean result only means "we have no local reason to
+    expect a refusal". A non-``None`` result names the actual field value
+    so the resulting error is never a guessed cause.
+
+    Fields absent or not the expected type are treated as "unknown" and
+    never block the write — we only refuse locally when we have positive
+    evidence it will fail.
+    """
+    remote_enable = state.get("RemoteEnable")
+    if (
+        isinstance(remote_enable, list)
+        and len(remote_enable) > REMOTE_ENABLE_FULL_CONTROL_INDEX
+        and isinstance(remote_enable[REMOTE_ENABLE_FULL_CONTROL_INDEX], int)
+        and remote_enable[REMOTE_ENABLE_FULL_CONTROL_INDEX] != REMOTE_ENABLE_FULL_CONTROL_VALUE
+    ):
+        return (
+            "Remote control is not enabled on this appliance "
+            f"(RemoteEnable={remote_enable!r}). Enable 'Remote control' / "
+            "'Mobile controllable' in the appliance's settings menu and try again."
+        )
+    if action == PROCESS_ACTION_START:
+        status = state.get("Status")
+        if isinstance(status, int) and status != STATUS_WAITING_TO_START:
+            return (
+                f"This appliance is not ready to start (Status={status}, "
+                f"expected {STATUS_WAITING_TO_START} = waiting to start). "
+                "Select and confirm a programme on the appliance first."
+            )
+    return None
 
 
 # --- Dop1 request builders --------------------------------------------------
@@ -403,6 +448,59 @@ class MieleLanClient:
     async def wake(self) -> dict[str, Any]:
         """Wake the appliance from sleep. Returns the device's action ack."""
         return await self._put_state({"DeviceAction": DEVICE_ACTION_WAKE})
+
+    async def send_process_action(
+        self, action: int, *, precondition_state: dict[str, Any] | None = None
+    ) -> None:
+        """PUT /State {"ProcessAction": action} — start/stop/pause/resume a programme.
+
+        This is the only control surface some appliances expose at all: a
+        whole hardware/firmware family (EK057) answers HTTP 404 to every
+        DOP2 leaf, including GLOBAL_USER_REQ (`write_user_request`), so
+        `/State` is not a fallback here — it's the sole path for those
+        devices. Confirmed against the reference implementation
+        (MieleRESTServer), which performs remote start the same way.
+
+        Unlike `_put_state` (used by `wake`/`light_on`/`light_off`), a
+        refused process action is a real failure rather than a re-assertion
+        of an already-current value, so HTTP 400 is not treated as success
+        here — doing so previously produced a misleading "it worked" for a
+        command the appliance actually rejected.
+
+        `precondition_state` is the caller's last-known `/State` (no network
+        round trip) — when given, a write we already have positive evidence
+        will fail is rejected locally with the actual field values named,
+        instead of firing a request that's certain to be refused. See
+        `check_process_action_precondition` for what "positive evidence"
+        means and why a clean result is not a success guarantee.
+        """
+        if precondition_state is not None:
+            reason = check_process_action_precondition(precondition_state, action)
+            if reason:
+                raise HomeAssistantError(reason)
+        try:
+            await self._client._request_bytes(
+                "PUT",
+                f"/Devices/{self._route}/State",
+                body={"ProcessAction": action},
+                allowed_status=(200, 204),
+            )
+        except ResponseError as exc:
+            raise HomeAssistantError(
+                f"The appliance refused this command (HTTP {exc.status_code})."
+            ) from exc
+
+    async def start_process(self, precondition_state: dict[str, Any] | None = None) -> None:
+        await self.send_process_action(PROCESS_ACTION_START, precondition_state=precondition_state)
+
+    async def stop_process(self, precondition_state: dict[str, Any] | None = None) -> None:
+        await self.send_process_action(PROCESS_ACTION_STOP, precondition_state=precondition_state)
+
+    async def pause_process(self, precondition_state: dict[str, Any] | None = None) -> None:
+        await self.send_process_action(PROCESS_ACTION_PAUSE, precondition_state=precondition_state)
+
+    async def resume_process(self, precondition_state: dict[str, Any] | None = None) -> None:
+        await self.send_process_action(PROCESS_ACTION_RESUME, precondition_state=precondition_state)
 
     async def write_user_request(self, opcode: int) -> None:
         """Send a GLOBAL_USER_REQ opcode via DOP2 leaf 2/1583.

--- a/custom_components/miele_lan/button.py
+++ b/custom_components/miele_lan/button.py
@@ -1,10 +1,21 @@
 """Miele@LAN buttons — only entries that don't have a more natural
 on/off representation as a switch / light.
 
-* `wake`         — devices with deep-standby. Sends DeviceAction:2 to
+* `wake`          — devices with deep-standby. Sends DeviceAction:2 to
   pull the device back to a remote-controllable state.
-* `stop_program` — oven-family. Sends DOP2 STOP (no heat risk; cleanly
-  ends a running program).
+* `stop_program`  — oven-family. Sends DOP2 STOP (no heat risk; cleanly
+  ends a running program) via GLOBAL_USER_REQ.
+* `start_process`, `pause_process`, `resume_process` — cycle devices
+  (oven/laundry/dishwasher). Send `ProcessAction` via `PUT /State` instead
+  of DOP2 — the only control surface on appliances whose firmware blocks
+  DOP2 writes outright (HTTP 404 on every leaf). Ovens have no existing
+  start/pause/resume equivalent, so there's no duplication there.
+* `stop_process`  — laundry + dishwasher only (STOP_PROCESS_FAMILY), same
+  `PUT /State` mechanism. Deliberately excludes ovens: they already have a
+  working `stop_program`, we have no evidence the two stop mechanisms
+  behave identically, and a second unproven "Stop" would just leave an
+  oven owner guessing which button to press for no gain — see
+  `STOP_PROCESS_FAMILY` in const.py.
 """
 
 from __future__ import annotations
@@ -17,11 +28,16 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .api import MieleLanClient
 from .const import (
+    CYCLE_FAMILY,
     DOMAIN,
     OPCODE_STOP,
     OVEN_FAMILY,
+    PROCESS_ACTION_PAUSE,
+    PROCESS_ACTION_RESUME,
+    PROCESS_ACTION_START,
+    PROCESS_ACTION_STOP,
+    STOP_PROCESS_FAMILY,
     WAKEABLE_FAMILY,
     MieleAppliance,
 )
@@ -31,7 +47,7 @@ from .entity import MieleLanEntity
 
 @dataclass(frozen=True, kw_only=True)
 class MieleLanButtonDescription(ButtonEntityDescription):
-    press_fn: Callable[[MieleLanClient], Awaitable[Any]]
+    press_fn: Callable[[MieleLanCoordinator], Awaitable[Any]]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -40,13 +56,21 @@ class MieleLanButtonDef:
     description: MieleLanButtonDescription
 
 
+def _process_action_press(action: int) -> Callable[[MieleLanCoordinator], Awaitable[Any]]:
+    async def press(coordinator: MieleLanCoordinator) -> None:
+        state = coordinator.data.state if coordinator.data else None
+        await coordinator.client.send_process_action(action, precondition_state=state)
+
+    return press
+
+
 BUTTONS: tuple[MieleLanButtonDef, ...] = (
     MieleLanButtonDef(
         types=WAKEABLE_FAMILY,
         description=MieleLanButtonDescription(
             key="wake",
             translation_key="wake",
-            press_fn=lambda c: c.wake(),
+            press_fn=lambda coord: coord.client.wake(),
         ),
     ),
     MieleLanButtonDef(
@@ -54,7 +78,39 @@ BUTTONS: tuple[MieleLanButtonDef, ...] = (
         description=MieleLanButtonDescription(
             key="stop_program",
             translation_key="stop_program",
-            press_fn=lambda c: c.write_user_request(OPCODE_STOP),
+            press_fn=lambda coord: coord.client.write_user_request(OPCODE_STOP),
+        ),
+    ),
+    MieleLanButtonDef(
+        types=CYCLE_FAMILY,
+        description=MieleLanButtonDescription(
+            key="start_process",
+            translation_key="start_process",
+            press_fn=_process_action_press(PROCESS_ACTION_START),
+        ),
+    ),
+    MieleLanButtonDef(
+        types=STOP_PROCESS_FAMILY,
+        description=MieleLanButtonDescription(
+            key="stop_process",
+            translation_key="stop_process",
+            press_fn=_process_action_press(PROCESS_ACTION_STOP),
+        ),
+    ),
+    MieleLanButtonDef(
+        types=CYCLE_FAMILY,
+        description=MieleLanButtonDescription(
+            key="pause_process",
+            translation_key="pause_process",
+            press_fn=_process_action_press(PROCESS_ACTION_PAUSE),
+        ),
+    ),
+    MieleLanButtonDef(
+        types=CYCLE_FAMILY,
+        description=MieleLanButtonDescription(
+            key="resume_process",
+            translation_key="resume_process",
+            press_fn=_process_action_press(PROCESS_ACTION_RESUME),
         ),
     ),
 )
@@ -89,5 +145,5 @@ class MieleLanButton(MieleLanEntity, ButtonEntity):
         self.entity_description = description
 
     async def async_press(self) -> None:
-        await self.entity_description.press_fn(self.coordinator.client)
+        await self.entity_description.press_fn(self.coordinator)
         await self.coordinator.async_request_refresh()

--- a/custom_components/miele_lan/const.py
+++ b/custom_components/miele_lan/const.py
@@ -52,6 +52,16 @@ DEVICE_ACTION_WAKE = 2
 PROCESS_ACTION_START = 1
 PROCESS_ACTION_STOP = 2
 PROCESS_ACTION_PAUSE = 3
+PROCESS_ACTION_RESUME = 6
+
+# Preconditions for a `ProcessAction` write (see MieleLanClient.send_process_action).
+# Sourced from the reference implementation's readiness gate (MieleRESTServer:
+# DeviceReadyToStart = Status==0x04, DeviceRemoteStartCapable = 15 in
+# RemoteEnable) and cross-checked against our own StateStatus[4] ==
+# "waiting_to_start" (enums.py) and REMOTE_LABELS[15] == "full" (sensor.py).
+STATUS_WAITING_TO_START = 4
+REMOTE_ENABLE_FULL_CONTROL_INDEX = 0
+REMOTE_ENABLE_FULL_CONTROL_VALUE = 15
 
 # DOP2 GLOBAL_USER_REQ leaf — universal across oven, laundry, dishwasher.
 USER_REQUEST_UNIT = 2
@@ -217,6 +227,18 @@ DISHWASHER_FAMILY: tuple[MieleAppliance, ...] = (
 # Cycle devices = devices that run a "program" with phases, remaining time, etc.
 CYCLE_FAMILY: tuple[MieleAppliance, ...] = (
     *OVEN_FAMILY, *LAUNDRY_FAMILY, *DISHWASHER_FAMILY,
+)
+
+# Devices that get the /State ProcessAction "stop" button (button.py:
+# stop_process). Deliberately excludes ovens: they already have a working
+# stop via the DOP2 GLOBAL_USER_REQ button (stop_program), and we have no
+# evidence the two mechanisms behave identically, so shipping both would
+# just leave an oven owner guessing which one to press. Laundry and
+# dishwasher are exactly the families this PUT /State path exists for —
+# appliances that have no DOP2 stop at all on firmware that blocks DOP2
+# writes outright.
+STOP_PROCESS_FAMILY: tuple[MieleAppliance, ...] = (
+    *LAUNDRY_FAMILY, *DISHWASHER_FAMILY,
 )
 
 HOB_FAMILY: tuple[MieleAppliance, ...] = (

--- a/custom_components/miele_lan/sensor.py
+++ b/custom_components/miele_lan/sensor.py
@@ -33,6 +33,10 @@ from .const import (
     HOB_FAMILY,
     LAUNDRY_FAMILY,
     OVEN_FAMILY,
+    PROCESS_ACTION_PAUSE,
+    PROCESS_ACTION_RESUME,
+    PROCESS_ACTION_START,
+    PROCESS_ACTION_STOP,
     WINE_FAMILY,
     MieleAppliance,
     is_idle_state,
@@ -110,7 +114,13 @@ ALL_TYPES: tuple[MieleAppliance, ...] = tuple(
 # --- enum lookups (translation-key values) -----------------------------------
 STATUS_LABELS = enums.StateStatus
 PROGRAM_TYPE_LABELS = enums.StateProgramType
-PROCESS_ACTION_LABELS = {0: "no_action", 1: "start", 2: "stop", 3: "pause", 6: "resume"}
+PROCESS_ACTION_LABELS = {
+    0: "no_action",
+    PROCESS_ACTION_START: "start",
+    PROCESS_ACTION_STOP: "stop",
+    PROCESS_ACTION_PAUSE: "pause",
+    PROCESS_ACTION_RESUME: "resume",
+}
 DEVICE_ACTION_LABELS = {0: "no_action", 1: "start_remote", 2: "wake_up", 3: "go_to_standby"}
 STANDBY_STATE_LABELS = {0: "not_in_standby", 1: "network_idle", 2: "deep_standby", 3: "going_to_standby"}
 SYNC_STATE_LABELS = {0: "unknown", 1: "synced", 2: "out_of_sync"}

--- a/custom_components/miele_lan/strings.json
+++ b/custom_components/miele_lan/strings.json
@@ -2170,6 +2170,18 @@
       },
       "stop_program": {
         "name": "Stop program"
+      },
+      "start_process": {
+        "name": "Start"
+      },
+      "stop_process": {
+        "name": "Stop (remote)"
+      },
+      "pause_process": {
+        "name": "Pause"
+      },
+      "resume_process": {
+        "name": "Resume"
       }
     },
     "fan": {

--- a/custom_components/miele_lan/translations/de.json
+++ b/custom_components/miele_lan/translations/de.json
@@ -2186,6 +2186,18 @@
       },
       "stop_program": {
         "name": "Programm stoppen"
+      },
+      "start_process": {
+        "name": "Start"
+      },
+      "stop_process": {
+        "name": "Stopp (Fernsteuerung)"
+      },
+      "pause_process": {
+        "name": "Pause"
+      },
+      "resume_process": {
+        "name": "Fortsetzen"
       }
     },
     "fan": {

--- a/custom_components/miele_lan/translations/en.json
+++ b/custom_components/miele_lan/translations/en.json
@@ -2176,6 +2176,18 @@
       },
       "stop_program": {
         "name": "Stop program"
+      },
+      "start_process": {
+        "name": "Start"
+      },
+      "stop_process": {
+        "name": "Stop (remote)"
+      },
+      "pause_process": {
+        "name": "Pause"
+      },
+      "resume_process": {
+        "name": "Resume"
       }
     },
     "fan": {

--- a/tests/test_button_process_action_families.py
+++ b/tests/test_button_process_action_families.py
@@ -1,0 +1,75 @@
+"""Tests for the start/stop/pause/resume button-to-appliance mapping.
+
+`STOP_PROCESS_FAMILY` (const.py) is pure and needs no Home Assistant.
+`button.BUTTONS` itself imports `homeassistant.components.button`, so it
+still runs without an `hass` instance — same reasoning as
+test_switch_power_gate.py, just one layer up.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from custom_components.miele_lan.const import (  # noqa: E402
+    CYCLE_FAMILY,
+    DISHWASHER_FAMILY,
+    LAUNDRY_FAMILY,
+    OVEN_FAMILY,
+    STOP_PROCESS_FAMILY,
+    MieleAppliance,
+)
+
+
+def test_stop_process_family_excludes_every_oven() -> None:
+    assert set(STOP_PROCESS_FAMILY).isdisjoint(OVEN_FAMILY)
+
+
+def test_stop_process_family_is_laundry_plus_dishwasher() -> None:
+    assert set(STOP_PROCESS_FAMILY) == set(LAUNDRY_FAMILY) | set(DISHWASHER_FAMILY)
+
+
+def test_stop_process_family_is_a_subset_of_cycle_family() -> None:
+    assert set(STOP_PROCESS_FAMILY) <= set(CYCLE_FAMILY)
+
+
+def test_no_appliance_gets_two_stop_buttons() -> None:
+    from custom_components.miele_lan import button
+
+    for device_type in MieleAppliance:
+        if device_type is MieleAppliance.UNKNOWN:
+            continue
+        stop_keys = [
+            d.description.key
+            for d in button.BUTTONS
+            if device_type in d.types and "stop" in d.description.key
+        ]
+        assert len(stop_keys) <= 1, f"{device_type} would get two stop buttons: {stop_keys}"
+
+
+def test_oven_keeps_dop2_stop_program_only() -> None:
+    from custom_components.miele_lan import button
+
+    keys_for_oven = {
+        d.description.key for d in button.BUTTONS if MieleAppliance.OVEN in d.types
+    }
+    assert "stop_program" in keys_for_oven
+    assert "stop_process" not in keys_for_oven
+
+
+def test_dishwasher_and_laundry_get_stop_process_not_stop_program() -> None:
+    from custom_components.miele_lan import button
+
+    for device_type in (MieleAppliance.DISHWASHER, MieleAppliance.WASHING_MACHINE):
+        keys = {d.description.key for d in button.BUTTONS if device_type in d.types}
+        assert "stop_process" in keys
+        assert "stop_program" not in keys
+
+
+def test_start_pause_resume_stay_on_full_cycle_family() -> None:
+    from custom_components.miele_lan import button
+
+    for key in ("start_process", "pause_process", "resume_process"):
+        (matching_def,) = [d for d in button.BUTTONS if d.description.key == key]
+        assert set(matching_def.types) == set(CYCLE_FAMILY)

--- a/tests/test_process_action_controls.py
+++ b/tests/test_process_action_controls.py
@@ -1,0 +1,145 @@
+"""Tests for Start/Stop/Pause/Resume via PUT /State (issue #10, #16).
+
+No HA runtime, no network — same stub pattern as
+tests/test_write_user_request_errors.py. Covers both the wire payload
+(correct ProcessAction value, correct resource) and the precondition
+logic, which must be usable without a device or a coordinator.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from asyncmiele.exceptions.network import ResponseError  # noqa: E402
+from homeassistant.exceptions import HomeAssistantError  # noqa: E402
+
+from custom_components.miele_lan.api import (  # noqa: E402
+    MieleLanClient,
+    check_process_action_precondition,
+)
+from custom_components.miele_lan.const import (  # noqa: E402
+    PROCESS_ACTION_PAUSE,
+    PROCESS_ACTION_RESUME,
+    PROCESS_ACTION_START,
+    PROCESS_ACTION_STOP,
+)
+
+
+class _RecordingRawClient:
+    """Stub replacing the asyncmiele MieleClient underneath MieleLanClient."""
+
+    def __init__(self, *, raise_status: int | None = None) -> None:
+        self.calls: list[tuple[str, str, object]] = []
+        self._raise_status = raise_status
+
+    async def _request_bytes(self, method, resource, *, body=None, allowed_status=(200,)):
+        self.calls.append((method, resource, body))
+        if self._raise_status is not None:
+            raise ResponseError(self._raise_status, "stub failure")
+        return 200, b""
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# --- wire payload ------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "method_name,expected_action",
+    [
+        ("start_process", PROCESS_ACTION_START),
+        ("stop_process", PROCESS_ACTION_STOP),
+        ("pause_process", PROCESS_ACTION_PAUSE),
+        ("resume_process", PROCESS_ACTION_RESUME),
+    ],
+)
+def test_process_action_sends_correct_put_state(method_name: str, expected_action: int) -> None:
+    stub = _RecordingRawClient()
+    client = MieleLanClient(stub, route="000000000000")
+    _run(getattr(client, method_name)())
+    assert len(stub.calls) == 1
+    method, resource, body = stub.calls[0]
+    assert method == "PUT"
+    assert resource == "/Devices/000000000000/State"
+    assert body == {"ProcessAction": expected_action}
+
+
+def test_refusal_is_not_swallowed_as_success() -> None:
+    """A 400 must surface as a refusal here, unlike `_put_state`'s no-op
+
+    convention for idempotent fields (Light, DeviceAction) — treating a
+    refused Start/Stop as silent success is the exact misleading-error
+    pattern issue #16 already cost a reporter an afternoon on.
+    """
+    stub = _RecordingRawClient(raise_status=400)
+    client = MieleLanClient(stub, route="000000000000")
+    with pytest.raises(HomeAssistantError) as exc_info:
+        _run(client.start_process())
+    assert "400" in str(exc_info.value)
+
+
+def test_500_does_not_assert_a_specific_cause() -> None:
+    stub = _RecordingRawClient(raise_status=500)
+    client = MieleLanClient(stub, route="000000000000")
+    with pytest.raises(HomeAssistantError) as exc_info:
+        _run(client.stop_process())
+    message = str(exc_info.value)
+    assert "500" in message
+    assert "Remote control" not in message
+    assert "panel" not in message.lower()
+
+
+# --- precondition (pure, no I/O) ---------------------------------------------
+
+def test_precondition_none_when_state_unknown() -> None:
+    assert check_process_action_precondition({}, PROCESS_ACTION_START) is None
+
+
+def test_precondition_blocks_when_remote_control_disabled() -> None:
+    state = {"RemoteEnable": [0, 0, 0], "Status": 4}
+    message = check_process_action_precondition(state, PROCESS_ACTION_STOP)
+    assert message is not None
+    assert "RemoteEnable" in message
+    assert "[0, 0, 0]" in message
+
+
+def test_precondition_blocks_start_when_not_waiting_to_start() -> None:
+    state = {"RemoteEnable": [15, 1, 1], "Status": 5}
+    message = check_process_action_precondition(state, PROCESS_ACTION_START)
+    assert message is not None
+    assert "Status=5" in message
+
+
+def test_precondition_does_not_apply_status_gate_to_stop() -> None:
+    """Status==4 ("waiting to start") is only documented as a Start gate."""
+    state = {"RemoteEnable": [15, 1, 1], "Status": 5}
+    assert check_process_action_precondition(state, PROCESS_ACTION_STOP) is None
+
+
+def test_precondition_passes_when_ready_to_start() -> None:
+    state = {"RemoteEnable": [15, 1, 1], "Status": 4}
+    assert check_process_action_precondition(state, PROCESS_ACTION_START) is None
+
+
+# --- client wiring of the precondition ---------------------------------------
+
+def test_client_blocks_locally_without_a_network_call() -> None:
+    stub = _RecordingRawClient()
+    client = MieleLanClient(stub, route="000000000000")
+    state = {"RemoteEnable": [0, 0, 0], "Status": 4}
+    with pytest.raises(HomeAssistantError):
+        _run(client.start_process(state))
+    assert stub.calls == []
+
+
+def test_client_proceeds_when_precondition_state_is_missing() -> None:
+    stub = _RecordingRawClient()
+    client = MieleLanClient(stub, route="000000000000")
+    _run(client.start_process(None))
+    assert len(stub.calls) == 1


### PR DESCRIPTION
Addresses #10 (two reporters), and gives #16 something concrete to test.

A whole hardware family — EK057, firmware 08.x — answers **HTTP 404 to every DOP2 leaf**. Three reporters have now confirmed that with `dump_dop2_leaf`. So every control built on DOP2 writes is dead on those appliances, and until now the only button they got was Wake.

## The mechanism is not a guess

`MieleRESTServer` performs remote start as a plain `PUT /State`:

```python
def set_process_action(self):
    command = json.dumps({"ProcessAction": 1})
    PUT Devices/{device_route}/State
```

We already had every piece: `_put_state()` is what `light_on()` and `wake()` use, and `PROCESS_ACTION_LABELS` has carried `{1: start, 2: stop, 3: pause, 6: resume}` all along — as read-only sensor labels we never wired up as writes. The numbers now live once in `const.py` and the sensor labels derive from them.

## Button mapping

| Button | Appliances | Write |
|---|---|---|
| `start_process` | oven, laundry, dishwasher | `ProcessAction: 1` |
| `stop_process` | **laundry, dishwasher** | `ProcessAction: 2` |
| `pause_process` | oven, laundry, dishwasher | `ProcessAction: 3` |
| `resume_process` | oven, laundry, dishwasher | `ProcessAction: 6` |

Ovens are deliberately excluded from `stop_process`: they already have `stop_program`, which uses the DOP2 path and works. Two stop buttons with no way to tell them apart is worse than the gap it would cover, and we have no evidence the two mechanisms behave identically. A test asserts no appliance type can ever end up with both.

## Error behaviour

This is the part with history. #16 was a 500 reported as "Remote control was refused", which sent a reporter to a setting that was already correct.

- **HTTP 400 is not swallowed.** `_put_state` treats 400 as "already at that value" — right for a light, wrong for a one-shot command, where it would silently report success for something the appliance rejected.
- **Local refusals name the actual value**, never a guessed cause: `RemoteEnable=[7, 0, 0]` verbatim, or `Status=5, expected 4 = waiting to start`.
- **Only two preconditions are checked**, both evidence-backed — full remote control, and Status 4 for start. No Status gate was invented for pause/resume, because nothing sources one.
- **A clean precondition check is documented as not being a success guarantee.** Upstream has two open reports where remote start was refused purely because of a physical selector-knob position, with every `/State` field correct. Missing or unexpected fields never block a write — we refuse locally only on positive evidence.

## Verification

- `pytest tests/ -q` → **202 passed** (182 + 20 new: payload correctness per action, 400 not swallowed, 500 not asserting a cause, precondition cases, and the family gating).
- Checked directly rather than by test name: oven's only stop button is `stop_program`; dishwasher's and washer's is `stop_process`.

## Not in this change

`DeviceAction: 3` ("go to standby") as a power-off for DOP2-less appliances. It is plausible and would address #16, but nothing has demonstrated it actually powers an appliance down. If a reporter confirms these buttons work on their EK057 machine, that establishes the `/State` write path on that hardware and makes the power question worth revisiting with evidence.