### PR TITLE
fix(button): Send Start for Resume and gate process buttons per appliance family

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Local Home Assistant integration for Miele@home appliances — ovens, hobs, dish
 
 | Family | Models | Sensors | Controls |
 |---|---|---|---|
-| **Oven** (incl. steam, combi, microwave) | H7560BP, H7164BP, DGC7860HCXL, DGM7440, … | status, program, phase, remaining/elapsed/start time, cavity & core temps, target & core-target, door, signals, light | start / stop / pause, wake, power, light, target temp* |
+| **Oven** (incl. steam, combi, microwave) | H7560BP, H7164BP, DGC7860HCXL, DGM7440, … | status, program, phase, remaining/elapsed/start time, cavity & core temps, target & core-target, door, signals, light | stop, wake, power, light, target temp* |
 | **Hob** | KM7576, KM7895 FL induction, induction + extractor | per-zone power (1..12 incl. ½ steps, boost/boost+, keep-warm), per-zone residual heat, per-zone timer, status | — |
-| **Dishwasher** | G7000-series + semi-pro/professional | status, program, phase, remaining/elapsed time, door, signals | start / stop / pause, wake, power |
-| **Washer / dryer / washer-dryer** | WWG/TWC/WWV/WTV series | status, program, phase, drying step, remaining/elapsed/start time, door, signals | start / stop / pause, wake |
+| **Dishwasher** | G7000-series + semi-pro/professional | status, program, phase, remaining/elapsed time, door, signals | start / stop / pause / resume, wake, power |
+| **Washer / dryer / washer-dryer** | WWG/TWC/WWV/WTV series | status, program, phase, drying step, remaining/elapsed/start time, door, signals | start / stop, wake |
 | **Fridge / freezer / fridge-freezer** | KF 7772 B, K 7000, KFN, KFNS, … | per-zone current + target temp, per-zone door, SuperCool, SuperFreeze, failure | — *(see Limitations)* |
 | **Wine cabinet** | KWT 6000, KWNS, KWTUS, wine + freezer | per-zone temp, per-zone door, light state | — *(see Limitations)* |
 | **Hood / range vent** | DA series, EK039W | fan step, light state, grease & charcoal filter saturation† | fan (off / 1-3 / boost)†, fan run-on time†, light |

--- a/custom_components/miele_lan/api.py
+++ b/custom_components/miele_lan/api.py
@@ -43,6 +43,7 @@ from asyncmiele.utils.http_consts import (
 
 from .const import (
     DEVICE_ACTION_WAKE,
+    DISHWASHER_FAMILY,
     DOP1_LIGHTINGMODE_COOKING,
     DOP1_LIGHTINGMODE_OFF,
     DOP1_LUEFTERSTEUERUNG_OBJECT_ID,
@@ -53,6 +54,7 @@ from .const import (
     DOP1_SWITCHLIGHT_LICHTQUELLE_MAIN,
     DOP1_SWITCHLIGHT_OBJECT_ID,
     DOP1_SWITCHLIGHT_STRUKTUR_VERSION,
+    LAUNDRY_FAMILY,
     OPCODE_LIGHT_OFF,
     OPCODE_LIGHT_ON,
     OPCODE_SWITCH_OFF,
@@ -60,12 +62,14 @@ from .const import (
     PROCESS_ACTION_PAUSE,
     PROCESS_ACTION_START,
     PROCESS_ACTION_STOP,
-    REMOTE_ENABLE_FULL_CONTROL_INDEX,
-    REMOTE_ENABLE_FULL_CONTROL_VALUE,
     RUN_ON_TIME_MINUTES,
+    STATUS_IN_USE,
+    STATUS_PROGRAMMED,
     STATUS_WAITING_TO_START,
     USER_REQUEST_LEAF,
     USER_REQUEST_UNIT,
+    MieleAppliance,
+    parse_minutes_field,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -108,7 +112,78 @@ def build_user_request_payload(opcode: int) -> bytes:
     return _OVEN_REQ_PREFIX + bytes([opcode]) + _OVEN_REQ_SUFFIX
 
 
-def check_process_action_precondition(state: dict[str, Any], action: int) -> str | None:
+def _check_dishwasher_precondition(state: dict[str, Any], action: int) -> str | None:
+    """Dishwasher's own `RemoteEnable`/`Status` gate is native-only code we
+    can't decompile, so we only refuse Start/Pause/Resume when `RemoteEnable[0]`
+    is positively known to be 0. Stop is never refused locally — the app never
+    gates it either.
+    """
+    if action == PROCESS_ACTION_STOP:
+        return None
+    remote_enable = state.get("RemoteEnable")
+    if (
+        isinstance(remote_enable, list)
+        and remote_enable
+        and isinstance(remote_enable[0], int)
+        and remote_enable[0] == 0
+    ):
+        return f"Remote control is off on this appliance (RemoteEnable={remote_enable!r})."
+    return None
+
+
+def _check_laundry_precondition(state: dict[str, Any], action: int) -> str | None:
+    """Laundry's exact `/State`-based gate (`UserRequestsDopSource` /
+    `DeviceStateExtensions`). Pause/Resume don't exist on this family at all
+    (no button is wired for them), so this only ever sees Start/Stop.
+
+    Stop needs no `RemoteEnable` check whatsoever — only `Status` in
+    {waiting_to_start, in_use}. Start additionally needs remote control on
+    (`RemoteEnable[0]` bit 0), and while a programme is merely "programmed"
+    (not yet waiting), needs mobile start on (`RemoteEnable[2]` bit 0) with
+    no delayed start queued.
+    """
+    status = state.get("Status")
+    if action == PROCESS_ACTION_STOP:
+        if not isinstance(status, int) or status in (STATUS_WAITING_TO_START, STATUS_IN_USE):
+            return None
+        return (
+            f"Stop is not available right now (Status={status}). Stop works while a "
+            "programme is waiting to start or running (Status 4 or 5)."
+        )
+    if action != PROCESS_ACTION_START:
+        return None
+
+    remote_enable = state.get("RemoteEnable")
+    remote0 = remote_enable[0] if isinstance(remote_enable, list) and remote_enable else None
+    if isinstance(remote0, int) and not remote0 & 1:
+        return f"Remote control is off on this appliance (RemoteEnable={remote_enable!r})."
+
+    if not isinstance(status, int):
+        return None
+    if status == STATUS_WAITING_TO_START:
+        return None
+    if status == STATUS_PROGRAMMED:
+        remote2 = (
+            remote_enable[2]
+            if isinstance(remote_enable, list) and len(remote_enable) > 2
+            else None
+        )
+        mobile_start_known_off = isinstance(remote2, int) and not remote2 & 1
+        minutes = parse_minutes_field(state.get("StartTime"))
+        start_time_known_positive = isinstance(minutes, int) and minutes > 0
+        if not mobile_start_known_off and not start_time_known_positive:
+            return None
+
+    return (
+        f"Start is not available right now (Status={status}, RemoteEnable={remote_enable!r}). "
+        "Start works when a programme is waiting to start (Status 4), or is programmed "
+        "(Status 3) with Mobile start on and no delayed start."
+    )
+
+
+def check_process_action_precondition(
+    state: dict[str, Any], action: int, device_type: MieleAppliance
+) -> str | None:
     """Whether a cached `/State` rules out a `ProcessAction` write before we send it.
 
     Pure and I/O-free so it can be tested without a device. Returns ``None``
@@ -121,28 +196,15 @@ def check_process_action_precondition(state: dict[str, Any], action: int) -> str
 
     Fields absent or not the expected type are treated as "unknown" and
     never block the write — we only refuse locally when we have positive
-    evidence it will fail.
+    evidence it will fail. The rule itself is per appliance family: laundry
+    and the dishwasher expose very different gating over `/State` (see
+    `_check_laundry_precondition` / `_check_dishwasher_precondition`), and
+    ovens get no `ProcessAction` buttons at all.
     """
-    remote_enable = state.get("RemoteEnable")
-    if (
-        isinstance(remote_enable, list)
-        and len(remote_enable) > REMOTE_ENABLE_FULL_CONTROL_INDEX
-        and isinstance(remote_enable[REMOTE_ENABLE_FULL_CONTROL_INDEX], int)
-        and remote_enable[REMOTE_ENABLE_FULL_CONTROL_INDEX] != REMOTE_ENABLE_FULL_CONTROL_VALUE
-    ):
-        return (
-            "Remote control is not enabled on this appliance "
-            f"(RemoteEnable={remote_enable!r}). Enable 'Remote control' / "
-            "'Mobile controllable' in the appliance's settings menu and try again."
-        )
-    if action == PROCESS_ACTION_START:
-        status = state.get("Status")
-        if isinstance(status, int) and status != STATUS_WAITING_TO_START:
-            return (
-                f"This appliance is not ready to start (Status={status}, "
-                f"expected {STATUS_WAITING_TO_START} = waiting to start). "
-                "Select and confirm a programme on the appliance first."
-            )
+    if device_type in DISHWASHER_FAMILY:
+        return _check_dishwasher_precondition(state, action)
+    if device_type in LAUNDRY_FAMILY:
+        return _check_laundry_precondition(state, action)
     return None
 
 
@@ -449,7 +511,11 @@ class MieleLanClient:
         return await self._put_state({"DeviceAction": DEVICE_ACTION_WAKE})
 
     async def send_process_action(
-        self, action: int, *, precondition_state: dict[str, Any] | None = None
+        self,
+        action: int,
+        *,
+        device_type: MieleAppliance | None = None,
+        precondition_state: dict[str, Any] | None = None,
     ) -> None:
         """PUT /State {"ProcessAction": action} — start/stop/pause/resume a programme.
 
@@ -467,14 +533,15 @@ class MieleLanClient:
         command the appliance actually rejected.
 
         `precondition_state` is the caller's last-known `/State` (no network
-        round trip) — when given, a write we already have positive evidence
-        will fail is rejected locally with the actual field values named,
-        instead of firing a request that's certain to be refused. See
+        round trip) and `device_type` selects which family's gate applies —
+        when both are given, a write we already have positive evidence will
+        fail is rejected locally with the actual field values named, instead
+        of firing a request that's certain to be refused. See
         `check_process_action_precondition` for what "positive evidence"
         means and why a clean result is not a success guarantee.
         """
-        if precondition_state is not None:
-            reason = check_process_action_precondition(precondition_state, action)
+        if precondition_state is not None and device_type is not None:
+            reason = check_process_action_precondition(precondition_state, action, device_type)
             if reason:
                 raise HomeAssistantError(reason)
         try:
@@ -489,22 +556,50 @@ class MieleLanClient:
                 f"The appliance refused this command (HTTP {exc.status_code})."
             ) from exc
 
-    async def start_process(self, precondition_state: dict[str, Any] | None = None) -> None:
-        await self.send_process_action(PROCESS_ACTION_START, precondition_state=precondition_state)
+    async def start_process(
+        self,
+        *,
+        device_type: MieleAppliance | None = None,
+        precondition_state: dict[str, Any] | None = None,
+    ) -> None:
+        await self.send_process_action(
+            PROCESS_ACTION_START, device_type=device_type, precondition_state=precondition_state
+        )
 
-    async def stop_process(self, precondition_state: dict[str, Any] | None = None) -> None:
-        await self.send_process_action(PROCESS_ACTION_STOP, precondition_state=precondition_state)
+    async def stop_process(
+        self,
+        *,
+        device_type: MieleAppliance | None = None,
+        precondition_state: dict[str, Any] | None = None,
+    ) -> None:
+        await self.send_process_action(
+            PROCESS_ACTION_STOP, device_type=device_type, precondition_state=precondition_state
+        )
 
-    async def pause_process(self, precondition_state: dict[str, Any] | None = None) -> None:
-        await self.send_process_action(PROCESS_ACTION_PAUSE, precondition_state=precondition_state)
+    async def pause_process(
+        self,
+        *,
+        device_type: MieleAppliance | None = None,
+        precondition_state: dict[str, Any] | None = None,
+    ) -> None:
+        await self.send_process_action(
+            PROCESS_ACTION_PAUSE, device_type=device_type, precondition_state=precondition_state
+        )
 
-    async def resume_process(self, precondition_state: dict[str, Any] | None = None) -> None:
+    async def resume_process(
+        self,
+        *,
+        device_type: MieleAppliance | None = None,
+        precondition_state: dict[str, Any] | None = None,
+    ) -> None:
         """Resume a paused programme.
 
         There is no Resume opcode — the app resumes by resending Start (1),
         and so do we.
         """
-        await self.send_process_action(PROCESS_ACTION_START, precondition_state=precondition_state)
+        await self.send_process_action(
+            PROCESS_ACTION_START, device_type=device_type, precondition_state=precondition_state
+        )
 
     async def write_user_request(self, opcode: int) -> None:
         """Send a GLOBAL_USER_REQ opcode via DOP2 leaf 2/1583.

--- a/custom_components/miele_lan/api.py
+++ b/custom_components/miele_lan/api.py
@@ -58,7 +58,6 @@ from .const import (
     OPCODE_SWITCH_OFF,
     OPCODE_SWITCH_ON,
     PROCESS_ACTION_PAUSE,
-    PROCESS_ACTION_RESUME,
     PROCESS_ACTION_START,
     PROCESS_ACTION_STOP,
     REMOTE_ENABLE_FULL_CONTROL_INDEX,
@@ -500,7 +499,12 @@ class MieleLanClient:
         await self.send_process_action(PROCESS_ACTION_PAUSE, precondition_state=precondition_state)
 
     async def resume_process(self, precondition_state: dict[str, Any] | None = None) -> None:
-        await self.send_process_action(PROCESS_ACTION_RESUME, precondition_state=precondition_state)
+        """Resume a paused programme.
+
+        There is no Resume opcode — the app resumes by resending Start (1),
+        and so do we.
+        """
+        await self.send_process_action(PROCESS_ACTION_START, precondition_state=precondition_state)
 
     async def write_user_request(self, opcode: int) -> None:
         """Send a GLOBAL_USER_REQ opcode via DOP2 leaf 2/1583.

--- a/custom_components/miele_lan/button.py
+++ b/custom_components/miele_lan/button.py
@@ -10,6 +10,8 @@ on/off representation as a switch / light.
   of DOP2 — the only control surface on appliances whose firmware blocks
   DOP2 writes outright (HTTP 404 on every leaf). Ovens have no existing
   start/pause/resume equivalent, so there's no duplication there.
+  `resume_process` has no dedicated opcode — it resends Start (1), same as
+  the official app (see `MieleLanClient.resume_process`).
 * `stop_process`  — laundry + dishwasher only (STOP_PROCESS_FAMILY), same
   `PUT /State` mechanism. Deliberately excludes ovens: they already have a
   working `stop_program`, we have no evidence the two stop mechanisms
@@ -34,7 +36,6 @@ from .const import (
     OPCODE_STOP,
     OVEN_FAMILY,
     PROCESS_ACTION_PAUSE,
-    PROCESS_ACTION_RESUME,
     PROCESS_ACTION_START,
     PROCESS_ACTION_STOP,
     STOP_PROCESS_FAMILY,
@@ -110,7 +111,7 @@ BUTTONS: tuple[MieleLanButtonDef, ...] = (
         description=MieleLanButtonDescription(
             key="resume_process",
             translation_key="resume_process",
-            press_fn=_process_action_press(PROCESS_ACTION_RESUME),
+            press_fn=_process_action_press(PROCESS_ACTION_START),
         ),
     ),
 )

--- a/custom_components/miele_lan/button.py
+++ b/custom_components/miele_lan/button.py
@@ -5,19 +5,16 @@ on/off representation as a switch / light.
   pull the device back to a remote-controllable state.
 * `stop_program`  — oven-family. Sends DOP2 STOP (no heat risk; cleanly
   ends a running program) via GLOBAL_USER_REQ.
-* `start_process`, `pause_process`, `resume_process` — cycle devices
-  (oven/laundry/dishwasher). Send `ProcessAction` via `PUT /State` instead
-  of DOP2 — the only control surface on appliances whose firmware blocks
-  DOP2 writes outright (HTTP 404 on every leaf). Ovens have no existing
-  start/pause/resume equivalent, so there's no duplication there.
-  `resume_process` has no dedicated opcode — it resends Start (1), same as
-  the official app (see `MieleLanClient.resume_process`).
-* `stop_process`  — laundry + dishwasher only (STOP_PROCESS_FAMILY), same
-  `PUT /State` mechanism. Deliberately excludes ovens: they already have a
-  working `stop_program`, we have no evidence the two stop mechanisms
-  behave identically, and a second unproven "Stop" would just leave an
-  oven owner guessing which button to press for no gain — see
-  `STOP_PROCESS_FAMILY` in const.py.
+* `start_process`, `stop_process` — laundry + dishwasher
+  (START_STOP_PROCESS_FAMILY). Send `ProcessAction` via `PUT /State`
+  instead of DOP2 — the only control surface on appliances whose firmware
+  blocks DOP2 writes outright (HTTP 404 on every leaf). Ovens are excluded:
+  DOP1 ovens hardcode Start as unavailable and DOP2 ovens use the existing
+  `stop_program` instead, mirroring exactly what the official app itself
+  offers over `/State` per appliance family.
+* `pause_process`, `resume_process` — dishwasher only. Resume has no
+  dedicated opcode; it resends Start (see `MieleLanClient.resume_process`).
+  Laundry's own `/State` source never offers Pause/Resume at all.
 """
 
 from __future__ import annotations
@@ -31,14 +28,14 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
-    CYCLE_FAMILY,
+    DISHWASHER_FAMILY,
     DOMAIN,
     OPCODE_STOP,
     OVEN_FAMILY,
     PROCESS_ACTION_PAUSE,
     PROCESS_ACTION_START,
     PROCESS_ACTION_STOP,
-    STOP_PROCESS_FAMILY,
+    START_STOP_PROCESS_FAMILY,
     WAKEABLE_FAMILY,
     MieleAppliance,
 )
@@ -60,7 +57,9 @@ class MieleLanButtonDef:
 def _process_action_press(action: int) -> Callable[[MieleLanCoordinator], Awaitable[Any]]:
     async def press(coordinator: MieleLanCoordinator) -> None:
         state = coordinator.data.state if coordinator.data else None
-        await coordinator.client.send_process_action(action, precondition_state=state)
+        await coordinator.client.send_process_action(
+            action, device_type=coordinator.device_type, precondition_state=state
+        )
 
     return press
 
@@ -83,7 +82,7 @@ BUTTONS: tuple[MieleLanButtonDef, ...] = (
         ),
     ),
     MieleLanButtonDef(
-        types=CYCLE_FAMILY,
+        types=START_STOP_PROCESS_FAMILY,
         description=MieleLanButtonDescription(
             key="start_process",
             translation_key="start_process",
@@ -91,7 +90,7 @@ BUTTONS: tuple[MieleLanButtonDef, ...] = (
         ),
     ),
     MieleLanButtonDef(
-        types=STOP_PROCESS_FAMILY,
+        types=START_STOP_PROCESS_FAMILY,
         description=MieleLanButtonDescription(
             key="stop_process",
             translation_key="stop_process",
@@ -99,7 +98,7 @@ BUTTONS: tuple[MieleLanButtonDef, ...] = (
         ),
     ),
     MieleLanButtonDef(
-        types=CYCLE_FAMILY,
+        types=DISHWASHER_FAMILY,
         description=MieleLanButtonDescription(
             key="pause_process",
             translation_key="pause_process",
@@ -107,7 +106,7 @@ BUTTONS: tuple[MieleLanButtonDef, ...] = (
         ),
     ),
     MieleLanButtonDef(
-        types=CYCLE_FAMILY,
+        types=DISHWASHER_FAMILY,
         description=MieleLanButtonDescription(
             key="resume_process",
             translation_key="resume_process",

--- a/custom_components/miele_lan/const.py
+++ b/custom_components/miele_lan/const.py
@@ -47,12 +47,12 @@ STATIC_IPS_TEXT_FIELD = "static_ips_text"  # options-flow free-form fab=ip texta
 CONF_FLOW_KIND = "flow_kind"        # "cloud" vs "manual" (single-device legacy path)
 DEFAULT_HA_PUSH_PORT = 18082
 
-# /State action keys.
+# /State action keys. There is no Resume value — the app resumes a paused
+# programme by resending Start (1); see MieleLanClient.resume_process.
 DEVICE_ACTION_WAKE = 2
 PROCESS_ACTION_START = 1
 PROCESS_ACTION_STOP = 2
 PROCESS_ACTION_PAUSE = 3
-PROCESS_ACTION_RESUME = 6
 
 # Preconditions for a `ProcessAction` write (see MieleLanClient.send_process_action).
 # Sourced from the reference implementation's readiness gate (MieleRESTServer:

--- a/custom_components/miele_lan/const.py
+++ b/custom_components/miele_lan/const.py
@@ -30,6 +30,23 @@ def is_idle_state(state: dict[str, Any]) -> bool:
     return not isinstance(status, int) or status in IDLE_STATUSES
 
 
+def parse_minutes_field(field: Any) -> int | None:
+    """Convert /State.RemainingTime/ElapsedTime/StartTime to total minutes.
+
+    Accepts either [hours, minutes] or a plain int of minutes, depending on
+    appliance. Negative values (e.g. the -32768 sentinel used elsewhere in
+    /State) are not a meaningful duration and are treated as unsupported.
+
+    Shared by sensor.py (RemainingTime/ElapsedTime/StartTime sensors) and
+    api.py (the laundry Start precondition's "no delayed start" check).
+    """
+    if isinstance(field, list) and len(field) == 2 and all(isinstance(x, int) for x in field):
+        return field[0] * 60 + field[1]
+    if isinstance(field, int) and not isinstance(field, bool) and field >= 0:
+        return field
+    return None
+
+
 CONF_GROUP_ID = "group_id"
 CONF_GROUP_KEY = "group_key"
 CONF_ROUTE = "route"
@@ -54,14 +71,15 @@ PROCESS_ACTION_START = 1
 PROCESS_ACTION_STOP = 2
 PROCESS_ACTION_PAUSE = 3
 
-# Preconditions for a `ProcessAction` write (see MieleLanClient.send_process_action).
-# Sourced from the reference implementation's readiness gate (MieleRESTServer:
-# DeviceReadyToStart = Status==0x04, DeviceRemoteStartCapable = 15 in
-# RemoteEnable) and cross-checked against our own StateStatus[4] ==
-# "waiting_to_start" (enums.py) and REMOTE_LABELS[15] == "full" (sensor.py).
+# /State.Status values used by the per-family `ProcessAction` preconditions
+# (see api.check_process_action_precondition). Sourced from the
+# official app's own laundry gate (UserRequestsDopSource /
+# DeviceStateExtensions): Stop needs Status in {waiting_to_start, in_use};
+# Start needs Status == waiting_to_start, or Status == programmed with
+# mobile start on and no delayed start queued.
+STATUS_PROGRAMMED = 3
 STATUS_WAITING_TO_START = 4
-REMOTE_ENABLE_FULL_CONTROL_INDEX = 0
-REMOTE_ENABLE_FULL_CONTROL_VALUE = 15
+STATUS_IN_USE = 5
 
 # DOP2 GLOBAL_USER_REQ leaf — universal across oven, laundry, dishwasher.
 USER_REQUEST_UNIT = 2
@@ -229,15 +247,17 @@ CYCLE_FAMILY: tuple[MieleAppliance, ...] = (
     *OVEN_FAMILY, *LAUNDRY_FAMILY, *DISHWASHER_FAMILY,
 )
 
-# Devices that get the /State ProcessAction "stop" button (button.py:
-# stop_process). Deliberately excludes ovens: they already have a working
-# stop via the DOP2 GLOBAL_USER_REQ button (stop_program), and we have no
-# evidence the two mechanisms behave identically, so shipping both would
-# just leave an oven owner guessing which one to press. Laundry and
-# dishwasher are exactly the families this PUT /State path exists for —
-# appliances that have no DOP2 stop at all on firmware that blocks DOP2
-# writes outright.
-STOP_PROCESS_FAMILY: tuple[MieleAppliance, ...] = (
+# Devices that get the /State ProcessAction Start/Stop buttons (button.py:
+# start_process, stop_process). Mirrors what the official app actually
+# offers over `/State`: laundry's UserRequestsDopSource offers Start(1)/
+# Stop(2) this way, and the dishwasher's app UI offers Start/Stop too
+# (its wire path is native code we couldn't decompile, so not verified
+# to also go through `/State`). Ovens are deliberately excluded — DOP1
+# ovens hardcode Start as unavailable and
+# DOP2 ovens use DOP2 GLOBAL_USER_REQ requests instead (the existing
+# stop_program button), so a second, unproven `/State` Start/Stop pair
+# would just leave an oven owner guessing which button to press.
+START_STOP_PROCESS_FAMILY: tuple[MieleAppliance, ...] = (
     *LAUNDRY_FAMILY, *DISHWASHER_FAMILY,
 )
 

--- a/custom_components/miele_lan/sensor.py
+++ b/custom_components/miele_lan/sensor.py
@@ -34,7 +34,6 @@ from .const import (
     LAUNDRY_FAMILY,
     OVEN_FAMILY,
     PROCESS_ACTION_PAUSE,
-    PROCESS_ACTION_RESUME,
     PROCESS_ACTION_START,
     PROCESS_ACTION_STOP,
     WINE_FAMILY,
@@ -119,7 +118,6 @@ PROCESS_ACTION_LABELS = {
     PROCESS_ACTION_START: "start",
     PROCESS_ACTION_STOP: "stop",
     PROCESS_ACTION_PAUSE: "pause",
-    PROCESS_ACTION_RESUME: "resume",
 }
 DEVICE_ACTION_LABELS = {0: "no_action", 1: "start_remote", 2: "wake_up", 3: "go_to_standby"}
 STANDBY_STATE_LABELS = {0: "not_in_standby", 1: "network_idle", 2: "deep_standby", 3: "going_to_standby"}

--- a/custom_components/miele_lan/sensor.py
+++ b/custom_components/miele_lan/sensor.py
@@ -39,6 +39,7 @@ from .const import (
     WINE_FAMILY,
     MieleAppliance,
     is_idle_state,
+    parse_minutes_field as _minutes,
 )
 from .coordinator import MieleLanCoordinator
 from .entity import MieleLanEntity
@@ -230,20 +231,6 @@ def _temp_or_none(temps: Any, idx: int, *, divisor: int = 100) -> int | float | 
     if not isinstance(v, int) or v == -32768:
         return None
     return v / divisor if divisor > 1 else v
-
-
-def _minutes(field: Any) -> int | None:
-    """Convert /State.RemainingTime/ElapsedTime/StartTime to total minutes.
-
-    Accepts either [hours, minutes] or a plain int of minutes, depending on
-    appliance. Negative values (e.g. the -32768 sentinel used elsewhere in
-    /State) are not a meaningful duration and are treated as unsupported.
-    """
-    if isinstance(field, list) and len(field) == 2 and all(isinstance(x, int) for x in field):
-        return field[0] * 60 + field[1]
-    if isinstance(field, int) and not isinstance(field, bool) and field >= 0:
-        return field
-    return None
 
 
 def _utc_iso_now_plus(minutes: int | None) -> str | None:

--- a/custom_components/miele_lan/strings.json
+++ b/custom_components/miele_lan/strings.json
@@ -978,8 +978,7 @@
           "no_action": "None",
           "start": "Start",
           "stop": "Stop",
-          "pause": "Pause",
-          "resume": "Resume"
+          "pause": "Pause"
         }
       },
       "device_action": {

--- a/custom_components/miele_lan/translations/de.json
+++ b/custom_components/miele_lan/translations/de.json
@@ -979,8 +979,7 @@
           "no_action": "Keine",
           "start": "Start",
           "stop": "Stopp",
-          "pause": "Pause",
-          "resume": "Fortsetzen"
+          "pause": "Pause"
         }
       },
       "device_action": {

--- a/custom_components/miele_lan/translations/en.json
+++ b/custom_components/miele_lan/translations/en.json
@@ -978,8 +978,7 @@
           "no_action": "None",
           "start": "Start",
           "stop": "Stop",
-          "pause": "Pause",
-          "resume": "Resume"
+          "pause": "Pause"
         }
       },
       "device_action": {

--- a/tests/test_button_process_action_families.py
+++ b/tests/test_button_process_action_families.py
@@ -1,9 +1,9 @@
 """Tests for the start/stop/pause/resume button-to-appliance mapping.
 
-`STOP_PROCESS_FAMILY` (const.py) is pure and needs no Home Assistant.
-`button.BUTTONS` itself imports `homeassistant.components.button`, so it
-still runs without an `hass` instance — same reasoning as
-test_switch_power_gate.py, just one layer up.
+`START_STOP_PROCESS_FAMILY` / `DISHWASHER_FAMILY` (const.py) are pure and
+need no Home Assistant. `button.BUTTONS` itself imports
+`homeassistant.components.button`, so it still runs without an `hass`
+instance — same reasoning as test_switch_power_gate.py, just one layer up.
 """
 
 import sys
@@ -17,21 +17,21 @@ from custom_components.miele_lan.const import (  # noqa: E402
     DISHWASHER_FAMILY,
     LAUNDRY_FAMILY,
     OVEN_FAMILY,
-    STOP_PROCESS_FAMILY,
+    START_STOP_PROCESS_FAMILY,
     MieleAppliance,
 )
 
 
-def test_stop_process_family_excludes_every_oven() -> None:
-    assert set(STOP_PROCESS_FAMILY).isdisjoint(OVEN_FAMILY)
+def test_start_stop_process_family_excludes_every_oven() -> None:
+    assert set(START_STOP_PROCESS_FAMILY).isdisjoint(OVEN_FAMILY)
 
 
-def test_stop_process_family_is_laundry_plus_dishwasher() -> None:
-    assert set(STOP_PROCESS_FAMILY) == set(LAUNDRY_FAMILY) | set(DISHWASHER_FAMILY)
+def test_start_stop_process_family_is_laundry_plus_dishwasher() -> None:
+    assert set(START_STOP_PROCESS_FAMILY) == set(LAUNDRY_FAMILY) | set(DISHWASHER_FAMILY)
 
 
-def test_stop_process_family_is_a_subset_of_cycle_family() -> None:
-    assert set(STOP_PROCESS_FAMILY) <= set(CYCLE_FAMILY)
+def test_start_stop_process_family_is_a_subset_of_cycle_family() -> None:
+    assert set(START_STOP_PROCESS_FAMILY) <= set(CYCLE_FAMILY)
 
 
 def test_no_appliance_gets_two_stop_buttons() -> None:
@@ -54,8 +54,7 @@ def test_oven_keeps_dop2_stop_program_only() -> None:
     keys_for_oven = {
         d.description.key for d in button.BUTTONS if MieleAppliance.OVEN in d.types
     }
-    assert "stop_program" in keys_for_oven
-    assert "stop_process" not in keys_for_oven
+    assert keys_for_oven == {"wake", "stop_program"}
 
 
 def test_dishwasher_and_laundry_get_stop_process_not_stop_program() -> None:
@@ -67,9 +66,35 @@ def test_dishwasher_and_laundry_get_stop_process_not_stop_program() -> None:
         assert "stop_program" not in keys
 
 
-def test_start_pause_resume_stay_on_full_cycle_family() -> None:
+def test_start_stop_stay_on_start_stop_process_family() -> None:
     from custom_components.miele_lan import button
 
-    for key in ("start_process", "pause_process", "resume_process"):
+    for key in ("start_process", "stop_process"):
         (matching_def,) = [d for d in button.BUTTONS if d.description.key == key]
-        assert set(matching_def.types) == set(CYCLE_FAMILY)
+        assert set(matching_def.types) == set(START_STOP_PROCESS_FAMILY)
+
+
+def test_pause_and_resume_are_dishwasher_only() -> None:
+    from custom_components.miele_lan import button
+
+    for key in ("pause_process", "resume_process"):
+        (matching_def,) = [d for d in button.BUTTONS if d.description.key == key]
+        assert set(matching_def.types) == set(DISHWASHER_FAMILY)
+
+
+def test_laundry_gets_no_pause_or_resume() -> None:
+    from custom_components.miele_lan import button
+
+    for device_type in LAUNDRY_FAMILY:
+        keys = {d.description.key for d in button.BUTTONS if device_type in d.types}
+        assert "pause_process" not in keys
+        assert "resume_process" not in keys
+
+
+def test_ovens_get_no_process_action_buttons() -> None:
+    from custom_components.miele_lan import button
+
+    process_action_keys = {"start_process", "stop_process", "pause_process", "resume_process"}
+    for device_type in OVEN_FAMILY:
+        keys = {d.description.key for d in button.BUTTONS if device_type in d.types}
+        assert keys.isdisjoint(process_action_keys)

--- a/tests/test_process_action_controls.py
+++ b/tests/test_process_action_controls.py
@@ -1,4 +1,4 @@
-"""Tests for Start/Stop/Pause/Resume via PUT /State (issue #10, #16).
+"""Tests for Start/Stop/Pause/Resume via PUT /State (issue #10, #16, #43).
 
 No HA runtime, no network — same stub pattern as
 tests/test_write_user_request_errors.py. Covers both the wire payload
@@ -24,7 +24,6 @@ from custom_components.miele_lan.api import (  # noqa: E402
 )
 from custom_components.miele_lan.const import (  # noqa: E402
     PROCESS_ACTION_PAUSE,
-    PROCESS_ACTION_RESUME,
     PROCESS_ACTION_START,
     PROCESS_ACTION_STOP,
 )
@@ -56,7 +55,7 @@ def _run(coro):
         ("start_process", PROCESS_ACTION_START),
         ("stop_process", PROCESS_ACTION_STOP),
         ("pause_process", PROCESS_ACTION_PAUSE),
-        ("resume_process", PROCESS_ACTION_RESUME),
+        ("resume_process", PROCESS_ACTION_START),
     ],
 )
 def test_process_action_sends_correct_put_state(method_name: str, expected_action: int) -> None:
@@ -68,6 +67,19 @@ def test_process_action_sends_correct_put_state(method_name: str, expected_actio
     assert method == "PUT"
     assert resource == "/Devices/000000000000/State"
     assert body == {"ProcessAction": expected_action}
+
+
+def test_resume_sends_start_not_supercooling() -> None:
+    """v1.13.0 shipped ProcessAction 6 for Resume — that's
+
+    GLOBAL_USER_REQ_START_SUPERCOOLING (a fridge feature), not Resume. The
+    app resumes a paused programme by resending Start (1).
+    """
+    stub = _RecordingRawClient()
+    client = MieleLanClient(stub, route="000000000000")
+    _run(client.resume_process())
+    _, _, body = stub.calls[0]
+    assert body == {"ProcessAction": PROCESS_ACTION_START}
 
 
 def test_refusal_is_not_swallowed_as_success() -> None:

--- a/tests/test_process_action_controls.py
+++ b/tests/test_process_action_controls.py
@@ -2,8 +2,8 @@
 
 No HA runtime, no network — same stub pattern as
 tests/test_write_user_request_errors.py. Covers both the wire payload
-(correct ProcessAction value, correct resource) and the precondition
-logic, which must be usable without a device or a coordinator.
+(correct ProcessAction value, correct resource) and the per-family
+precondition logic, which must be usable without a device or a coordinator.
 """
 
 import asyncio
@@ -26,6 +26,7 @@ from custom_components.miele_lan.const import (  # noqa: E402
     PROCESS_ACTION_PAUSE,
     PROCESS_ACTION_START,
     PROCESS_ACTION_STOP,
+    MieleAppliance,
 )
 
 
@@ -107,36 +108,165 @@ def test_500_does_not_assert_a_specific_cause() -> None:
     assert "panel" not in message.lower()
 
 
-# --- precondition (pure, no I/O) ---------------------------------------------
+# --- precondition: laundry ---------------------------------------------------
 
-def test_precondition_none_when_state_unknown() -> None:
-    assert check_process_action_precondition({}, PROCESS_ACTION_START) is None
+def test_laundry_precondition_none_when_state_unknown() -> None:
+    assert (
+        check_process_action_precondition({}, PROCESS_ACTION_START, MieleAppliance.WASHING_MACHINE)
+        is None
+    )
+    assert (
+        check_process_action_precondition({}, PROCESS_ACTION_STOP, MieleAppliance.WASHING_MACHINE)
+        is None
+    )
 
 
-def test_precondition_blocks_when_remote_control_disabled() -> None:
+def test_laundry_start_allowed_when_waiting_to_start() -> None:
+    state = {"RemoteEnable": [15, 0, 0], "Status": 4}
+    assert (
+        check_process_action_precondition(state, PROCESS_ACTION_START, MieleAppliance.WASHING_MACHINE)
+        is None
+    )
+
+
+def test_laundry_start_allowed_with_remote_enable_7() -> None:
+    """RemoteEnable[0]==7 ("enabled but not local") still has bit 0 set —
+
+    the app allows Start there just as it does at 15.
+    """
+    state = {"RemoteEnable": [7, 0, 0], "Status": 4}
+    assert (
+        check_process_action_precondition(state, PROCESS_ACTION_START, MieleAppliance.WASHING_MACHINE)
+        is None
+    )
+
+
+def test_laundry_start_allowed_when_programmed_with_mobile_start_and_no_delay() -> None:
+    state = {"RemoteEnable": [15, 0, 1], "Status": 3, "StartTime": 0}
+    assert (
+        check_process_action_precondition(state, PROCESS_ACTION_START, MieleAppliance.WASHING_MACHINE)
+        is None
+    )
+
+
+def test_laundry_start_refused_when_programmed_with_delayed_start() -> None:
+    state = {"RemoteEnable": [15, 0, 1], "Status": 3, "StartTime": [0, 30]}
+    message = check_process_action_precondition(
+        state, PROCESS_ACTION_START, MieleAppliance.WASHING_MACHINE
+    )
+    assert message == (
+        "Start is not available right now (Status=3, RemoteEnable=[15, 0, 1]). "
+        "Start works when a programme is waiting to start (Status 4), or is programmed "
+        "(Status 3) with Mobile start on and no delayed start."
+    )
+
+
+def test_laundry_start_refused_when_running() -> None:
+    state = {"RemoteEnable": [15, 0, 0], "Status": 5}
+    message = check_process_action_precondition(
+        state, PROCESS_ACTION_START, MieleAppliance.WASHING_MACHINE
+    )
+    assert message == (
+        "Start is not available right now (Status=5, RemoteEnable=[15, 0, 0]). "
+        "Start works when a programme is waiting to start (Status 4), or is programmed "
+        "(Status 3) with Mobile start on and no delayed start."
+    )
+
+
+def test_laundry_start_refused_when_remote_control_off() -> None:
     state = {"RemoteEnable": [0, 0, 0], "Status": 4}
-    message = check_process_action_precondition(state, PROCESS_ACTION_STOP)
-    assert message is not None
-    assert "RemoteEnable" in message
-    assert "[0, 0, 0]" in message
+    message = check_process_action_precondition(
+        state, PROCESS_ACTION_START, MieleAppliance.WASHING_MACHINE
+    )
+    assert message == "Remote control is off on this appliance (RemoteEnable=[0, 0, 0])."
 
 
-def test_precondition_blocks_start_when_not_waiting_to_start() -> None:
-    state = {"RemoteEnable": [15, 1, 1], "Status": 5}
-    message = check_process_action_precondition(state, PROCESS_ACTION_START)
-    assert message is not None
-    assert "Status=5" in message
+def test_laundry_stop_allowed_when_waiting_or_running() -> None:
+    for status in (4, 5):
+        state = {"RemoteEnable": [0, 0, 0], "Status": status}
+        assert (
+            check_process_action_precondition(state, PROCESS_ACTION_STOP, MieleAppliance.WASHING_MACHINE)
+            is None
+        )
 
 
-def test_precondition_does_not_apply_status_gate_to_stop() -> None:
-    """Status==4 ("waiting to start") is only documented as a Start gate."""
-    state = {"RemoteEnable": [15, 1, 1], "Status": 5}
-    assert check_process_action_precondition(state, PROCESS_ACTION_STOP) is None
+def test_laundry_stop_never_checks_remote_enable() -> None:
+    """Stop needs no RemoteEnable check at all — RemoteEnable[0]==0 must not
+
+    block it as long as Status is 4 or 5.
+    """
+    state = {"RemoteEnable": [0, 0, 0], "Status": 5}
+    assert (
+        check_process_action_precondition(state, PROCESS_ACTION_STOP, MieleAppliance.WASHING_MACHINE)
+        is None
+    )
 
 
-def test_precondition_passes_when_ready_to_start() -> None:
-    state = {"RemoteEnable": [15, 1, 1], "Status": 4}
-    assert check_process_action_precondition(state, PROCESS_ACTION_START) is None
+def test_laundry_stop_refused_when_not_waiting_or_running() -> None:
+    state = {"RemoteEnable": [15, 0, 0], "Status": 3}
+    message = check_process_action_precondition(
+        state, PROCESS_ACTION_STOP, MieleAppliance.WASHING_MACHINE
+    )
+    assert message == (
+        "Stop is not available right now (Status=3). Stop works while a "
+        "programme is waiting to start or running (Status 4 or 5)."
+    )
+
+
+# --- precondition: dishwasher -------------------------------------------------
+
+def test_dishwasher_start_refused_when_remote_control_off() -> None:
+    state = {"RemoteEnable": [0, 0, 0]}
+    message = check_process_action_precondition(
+        state, PROCESS_ACTION_START, MieleAppliance.DISHWASHER
+    )
+    assert message == "Remote control is off on this appliance (RemoteEnable=[0, 0, 0])."
+
+
+def test_dishwasher_pause_refused_when_remote_control_off() -> None:
+    state = {"RemoteEnable": [0, 0, 0]}
+    message = check_process_action_precondition(
+        state, PROCESS_ACTION_PAUSE, MieleAppliance.DISHWASHER
+    )
+    assert message == "Remote control is off on this appliance (RemoteEnable=[0, 0, 0])."
+
+
+def test_dishwasher_stop_never_refused() -> None:
+    state = {"RemoteEnable": [0, 0, 0]}
+    assert (
+        check_process_action_precondition(state, PROCESS_ACTION_STOP, MieleAppliance.DISHWASHER)
+        is None
+    )
+
+
+def test_dishwasher_start_allowed_when_remote_control_not_known_off() -> None:
+    for state in ({"RemoteEnable": [15, 0, 0]}, {"RemoteEnable": [7, 0, 0]}, {}):
+        assert (
+            check_process_action_precondition(state, PROCESS_ACTION_START, MieleAppliance.DISHWASHER)
+            is None
+        )
+
+
+# --- missing / malformed fields never block ----------------------------------
+
+def test_missing_or_malformed_fields_never_block() -> None:
+    malformed_states = [
+        {},
+        {"RemoteEnable": "not-a-list"},
+        {"RemoteEnable": []},
+        {"RemoteEnable": [None, 0, 0]},
+        {"Status": "not-an-int"},
+    ]
+    for state in malformed_states:
+        for device_type in (MieleAppliance.WASHING_MACHINE, MieleAppliance.DISHWASHER):
+            for action in (PROCESS_ACTION_START, PROCESS_ACTION_STOP, PROCESS_ACTION_PAUSE):
+                assert check_process_action_precondition(state, action, device_type) is None
+
+
+def test_oven_gets_no_process_action_precondition() -> None:
+    state = {"RemoteEnable": [0, 0, 0], "Status": 5}
+    for action in (PROCESS_ACTION_START, PROCESS_ACTION_STOP, PROCESS_ACTION_PAUSE):
+        assert check_process_action_precondition(state, action, MieleAppliance.OVEN) is None
 
 
 # --- client wiring of the precondition ---------------------------------------
@@ -146,12 +276,20 @@ def test_client_blocks_locally_without_a_network_call() -> None:
     client = MieleLanClient(stub, route="000000000000")
     state = {"RemoteEnable": [0, 0, 0], "Status": 4}
     with pytest.raises(HomeAssistantError):
-        _run(client.start_process(state))
+        _run(client.start_process(device_type=MieleAppliance.WASHING_MACHINE, precondition_state=state))
     assert stub.calls == []
 
 
 def test_client_proceeds_when_precondition_state_is_missing() -> None:
     stub = _RecordingRawClient()
     client = MieleLanClient(stub, route="000000000000")
-    _run(client.start_process(None))
+    _run(client.start_process(device_type=MieleAppliance.WASHING_MACHINE, precondition_state=None))
+    assert len(stub.calls) == 1
+
+
+def test_client_proceeds_when_device_type_is_missing() -> None:
+    stub = _RecordingRawClient()
+    client = MieleLanClient(stub, route="000000000000")
+    state = {"RemoteEnable": [0, 0, 0], "Status": 4}
+    _run(client.start_process(device_type=None, precondition_state=state))
     assert len(stub.calls) == 1


### PR DESCRIPTION
Fixes three problems with the v1.13.0 `PUT /State` `ProcessAction` buttons. The checks and button sets now match what Miele's own app does.

## 1. Resume sent a SuperCooling request

`ProcessAction` uses the same numbers as `GLOBAL_EnumUserRequestId`: 1 Start, 2 Stop, 3 Pause, **6 Start SuperCooling**. There is no Resume value. v1.13.0 sent 6.

The app's dishwasher Resume button sends Start (1). Resume now does the same.

The `process_action` sensor no longer labels 6 as `resume`.

## 2. Buttons per appliance family

| Button | Before | Now |
|---|---|---|
| `start_process` | oven, laundry, dishwasher | laundry, dishwasher |
| `stop_process` | laundry, dishwasher | laundry, dishwasher |
| `pause_process` | oven, laundry, dishwasher | dishwasher |
| `resume_process` | oven, laundry, dishwasher | dishwasher |

- **Ovens:** the app never sends Start/Pause/Resume over `/State`. Older ovens have Start switched off in the app, and newer ones use DOP2 requests. The existing oven `stop_program` button stays.
- **Laundry:** the app's `/State` path offers only Start and Stop (plus delayed start). It never offers Pause or Resume.

If you installed v1.13.0, the removed buttons stay in HA as leftover entities. Delete them from the entity list.

## 3. Checks before sending

The old check needed `RemoteEnable[0] == 15` for every action and `Status == 4` for Start. That rule came from an old MieleRESTServer version, not from the app. It blocked laundry Stop, which the app doesn't check at all. It also blocked the laundry Mobile Start flow (Status 3).

Now each family has its own check:

- **Laundry Stop:** `Status` is 4 or 5. No `RemoteEnable` check.
- **Laundry Start:** `RemoteEnable[0]` bit 0 set, and either `Status == 4`, or `Status == 3` with `RemoteEnable[2]` bit 0 set and `StartTime` of 0.
- **Dishwasher:** Start, Pause and Resume are refused only when `RemoteEnable[0] == 0`. Stop is never refused locally. The app's dishwasher rules are in native code and can't be read, so we don't guess.

A missing field, or one with an unexpected type, still never blocks a press.

Refusals name the actual values:
- `Remote control is off on this appliance (RemoteEnable=[0, 0, 0]).`
- `Start is not available right now (Status=5, RemoteEnable=[15, 0, 0]). Start works when a programme is waiting to start (Status 4), or is programmed (Status 3) with Mobile start on and no delayed start.`
- `Stop is not available right now (Status=3). Stop works while a programme is waiting to start or running (Status 4 or 5).`

Passing a local check does not mean the appliance will act. A test oven answered "success" to every `ProcessAction` value from 0 to 15, so a success response alone proves nothing.

## Also

- `_minutes` moved from `sensor.py` to `const.parse_minutes_field`, so the laundry Start check reads `StartTime` the same way the sensors do.
- README controls column updated for oven, dishwasher and washer/dryer.
